### PR TITLE
Add mount volumes and add persistent volumes in cluster role

### DIFF
--- a/monasca/templates/agent-daemonset.yaml
+++ b/monasca/templates/agent-daemonset.yaml
@@ -71,7 +71,7 @@ spec:
               value: {{ .Values.agent.namespace_annotations | quote}}
             {{- end}}
           volumeMounts:
-          - mountPath: /kubelet_plugins
+          - mountPath: /var/lib/kubelet/plugins
             name: kubelet-plugin-volume
       volumes:
       - name: kubelet-plugin-volume

--- a/monasca/templates/agent-daemonset.yaml
+++ b/monasca/templates/agent-daemonset.yaml
@@ -70,3 +70,10 @@ spec:
             - name: KUBERNETES_NAMESPACE_ANNOTATIONS
               value: {{ .Values.agent.namespace_annotations | quote}}
             {{- end}}
+          volumeMounts:
+          - mountPath: /kubelet_plugins
+            name: kubelet-plugin-volume
+      volumes:
+      - name: kubelet-plugin-volume
+        hostPath:
+          path: "/var/lib/kubelet/plugins"

--- a/monasca/templates/role.yaml
+++ b/monasca/templates/role.yaml
@@ -16,4 +16,5 @@ rules:
       - services
       - componentstatuses
       - storageclasses
+      - persistentvolumes
 {{- end }}


### PR DESCRIPTION
Mount /var/lib/kubelet/plugins onto /kubelet_plugins. Then inside monasca-agent container, it will have the permission to get usage information for directories under /kubelet_plugins which will be the persistent volume usages. 