### PR TITLE
Add job cleanup hook

### DIFF
--- a/monasca/templates/_helpers.tpl
+++ b/monasca/templates/_helpers.tpl
@@ -102,3 +102,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "client.fullname" -}}
 {{- printf "%s-%s" .Release.Name "client" | trunc 63 -}}
 {{- end -}}
+
+{{/*
+Create a fully qualified cleanup name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cleanup.fullname" -}}
+{{- printf "%s-%s" .Release.Name "cleanup" | trunc 63 -}}
+{{- end -}}

--- a/monasca/templates/cleanup-pre-upgrade-hook.yaml
+++ b/monasca/templates/cleanup-pre-upgrade-hook.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # while not recommended, we add a random sequence to the end of the job name
+  # this job will attempt to delete itself when finished, but should it fail for
+  # some reason we don't want future upgrades to fail because of a name conflict
+  # (plus the future runs of this job will delete any previous iterations that
+  # failed to clean themselves up)
+  name: "{{ template "cleanup.fullname" . }}-job-{{ randAlphaNum 5 | lower }}"
+  labels:
+    app: {{ template "fullname" . }}
+    component: "{{ .Values.cleanup.name }}-job"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        component: "{{ .Values.cleanup.name }}-job"
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: {{ template "name" . }}-{{ .Values.cleanup.name }}-job
+          image: "{{ .Values.cleanup.image.repository }}:{{ .Values.cleanup.image.tag }}"
+          imagePullPolicy: {{ .Values.cleanup.image.pullPolicy }}

--- a/monasca/templates/mysql-init-job.yaml
+++ b/monasca/templates/mysql-init-job.yaml
@@ -30,10 +30,7 @@ spec:
             - name: MYSQL_INIT_USERNAME
               value: "root"
             - name: MYSQL_INIT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Release.Name }}-mysql"
-                  key: "mysql-root-password"
+              value: "{{ .Values.mysql.mysqlRootPassword }}"
             - name: KEYSTONE_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -363,3 +363,10 @@ kafka:
   zookeeper:
     service:
       port: 2181
+
+cleanup:
+  name: cleanup
+  image:
+    repository: monasca/job-cleanup
+    tag: 1.0.0
+    pullPolicy: IfNotPresent

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -1,7 +1,7 @@
 mysql_init:
   image:
     repository: monasca/mysql-init
-    tag: 1.2.0
+    tag: 1.4.0
     pullPolicy: IfNotPresent
   disable_remote_root: true
 

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -3,7 +3,7 @@ mysql_init:
     repository: monasca/mysql-init
     tag: 1.4.0
     pullPolicy: IfNotPresent
-  disable_remote_root: true
+  disable_remote_root: false
 
 influx_init:
   image:
@@ -61,6 +61,7 @@ mysql:
     limits:
       memory: 1Gi
       cpu: 500m
+  mysqlRootPassword: secretmysql
   users:
     api:
       username: monapi


### PR DESCRIPTION
This adds a new helm upgrade hook to clean up old jobs. This avoids
any conflicting names if/when jobs get recreated.