### PR TITLE
Add option to override HipChat template

### DIFF
--- a/monasca/templates/notification-deployment.yaml
+++ b/monasca/templates/notification-deployment.yaml
@@ -17,12 +17,12 @@ spec:
         component: "{{ .Values.notification.name }}"
     spec:
       containers:
-      - name: {{ template "name" . }}-{{ .Values.notification.name }}
-        image: "{{ .Values.notification.image.repository }}:{{ .Values.notification.image.tag }}"
-        imagePullPolicy: {{ .Values.notification.image.pullPolicy }}
-        resources:
-{{ toYaml .Values.notification.resources | indent 10 }}
-        env:
+        - name: {{ template "name" . }}-{{ .Values.notification.name }}
+          image: "{{ .Values.notification.image.repository }}:{{ .Values.notification.image.tag }}"
+          imagePullPolicy: {{ .Values.notification.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.notification.resources | indent 12 }}
+          env:
             - name: MYSQL_DB_HOST
               value: "{{ .Release.Name }}-mysql"
             - name: MYSQL_DB_PORT
@@ -91,3 +91,22 @@ spec:
             - name: NF_SLACK_PROXY
               value: {{ .Values.notification.plugin_config.slack.proxy | quote }}
             {{- end }}
+            {{- if .Values.notification.plugin_config.hipchat.template }}
+            - name: NF_HIPCHAT_TEMPLATE
+              value: "/hipchat-template.yml.j2"
+            {{- end }}
+          {{- if .Values.notification.plugin_config.hipchat.template }}
+          volumeMounts:
+            - name: hipchat-template
+              mountPath: /hipchat-template.yml.j2
+              subPath: hipchat-template.yml.j2
+          {{- end }}
+      {{- if .Values.notification.plugin_config.hipchat.template }}
+      volumes:
+        - name: hipchat-template
+          configMap:
+            name: "{{ template "notification.fullname" . }}-hipchat-template"
+            items:
+              - key: hipchat-template.yml.j2
+                path: hipchat-template.yml.j2
+      {{- end }}

--- a/monasca/templates/notification-hipchat-configmap.yaml
+++ b/monasca/templates/notification-hipchat-configmap.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.notification.plugin_config.hipchat.template }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ template "notification.fullname" . }}-hipchat-template"
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.notification.name }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  hipchat-template.yml.j2: |
+{{ .Values.notification.plugin_config.hipchat.template | indent 4 }}
+{{- end }}

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -253,7 +253,7 @@ notification:
   name: notification
   image:
     repository: monasca/notification
-    tag: master
+    tag: master-20170504-225038
     pullPolicy: Always
   replicaCount: 1
   log_level: WARN


### PR DESCRIPTION
A custom HipChat template can now be specified in `values.yaml`. Also,
switch to unique versions (date + timestamp) of the notification
image.