### PR TITLE
Fix storm values.yaml

### DIFF
--- a/monasca/requirements.yaml
+++ b/monasca/requirements.yaml
@@ -9,5 +9,5 @@ dependencies:
   version: 0.1.0
   repository: http://monasca.io/monasca-helm-repo/
 - name: storm
-  version: 0.1.0
+  version: 0.2.0
   repository: http://monasca.io/monasca-helm-repo/

--- a/monasca/templates/aggregator-deployment.yaml
+++ b/monasca/templates/aggregator-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           - name: AGGREGATION_WINDOW_LAG
             value: {{ .Values.aggregator.window_lag | quote }}
           - name: KAFKA_URI
-            value: "{{ template "kafka.fullname" . }}:{{ .Values.kafka.service.port }}"
+            value: "{{ template "kafka.fullname" . }}:9092"
         volumeMounts:
           - name: aggregator-config
             mountPath: /aggregation-specifications.yaml

--- a/monasca/templates/api-deployment.yaml
+++ b/monasca/templates/api-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: LOG_LEVEL_CONSOLE
               value: {{ .Values.api.logging.log_level_console | quote }}
             - name: KAFKA_URI
-              value: {{ template "kafka.fullname" . }}:{{ .Values.kafka.service.port }}
+              value: "{{ template "kafka.fullname" . }}:9092"
             - name: INFLUX_HOST
               value: "{{ .Release.Name }}-influxdb"
             - name: INFLUX_PORT

--- a/monasca/templates/forwarder-deployment.yaml
+++ b/monasca/templates/forwarder-deployment.yaml
@@ -35,9 +35,9 @@ spec:
             - name: VERBOSE
               value: {{ .Values.forwarder.logging.verbose | quote }}
             - name: ZOOKEEPER_URL
-              value: "{{ template "zookeeper.fullname" . }}:{{ .Values.kafka.zookeeper.service.port }}"
+              value: "{{ template "zookeeper.fullname" . }}:2181"
             - name: KAFKA_URI
-              value: "{{ template "kafka.fullname" . }}:{{ .Values.kafka.service.port }}"
+              value: "{{ template "kafka.fullname" . }}:9092"
             - name: USE_INSECURE
               value: {{ .Values.forwarder.config.use_insecure | quote}}
             - name: MONASCA_ROLE

--- a/monasca/templates/notification-deployment.yaml
+++ b/monasca/templates/notification-deployment.yaml
@@ -40,9 +40,9 @@ spec:
             - name: MYSQL_DB_DATABASE
               value: "mon"
             - name: KAFKA_URI
-              value: "{{ template "kafka.fullname" . }}:{{ .Values.kafka.service.port }}"
+              value: "{{ template "kafka.fullname" . }}:9092"
             - name: ZOOKEEPER_URL
-              value: "{{ template "zookeeper.fullname" . }}:{{ .Values.kafka.zookeeper.service.port }}"
+              value: "{{ template "zookeeper.fullname" . }}:2181"
             - name: LOG_LEVEL
               value: {{ .Values.notification.log_level | quote }}
             - name: NF_PLUGINS

--- a/monasca/templates/persister-deployment.yaml
+++ b/monasca/templates/persister-deployment.yaml
@@ -28,9 +28,9 @@ spec:
             - name: VERBOSE
               value: {{ .Values.persister.logging.verbose | quote }}
             - name: ZOOKEEPER_URI
-              value: "{{ template "zookeeper.fullname" . }}:{{ .Values.kafka.zookeeper.service.port }}"
+              value: "{{ template "zookeeper.fullname" . }}:2181"
             - name: KAFKA_URI
-              value: "{{ template "kafka.fullname" . }}:{{ .Values.kafka.service.port }}"
+              value: "{{ template "kafka.fullname" . }}:9092"
             - name: INFLUX_PORT
               value: {{ .Values.influxdb.config.http.bind_address | quote }}
             - name: INFLUX_USER

--- a/monasca/templates/thresh-init-job.yaml
+++ b/monasca/templates/thresh-init-job.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    component: "{{ .Values.thresh.name }}-init-job"
+    component: "{{ .Values.storm.thresh.name }}-init-job"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -13,34 +13,34 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
-        component: "{{ .Values.thresh.name }}-init-job"
+        component: "{{ .Values.storm.thresh.name }}-init-job"
     spec:
       restartPolicy: OnFailure
       containers:
-        - name: {{ template "name" . }}-{{ .Values.thresh.name }}-init-job
-          image: "{{ .Values.thresh.image.repository }}:{{ .Values.thresh.image.tag }}"
-          imagePullPolicy: {{ .Values.thresh.image.pullPolicy }}
+        - name: {{ template "name" . }}-{{ .Values.storm.thresh.name }}-init-job
+          image: "{{ .Values.storm.thresh.image.repository }}:{{ .Values.storm.thresh.image.tag }}"
+          imagePullPolicy: {{ .Values.storm.thresh.image.pullPolicy }}
           env:
             - name: STORM_HOSTNAME_FROM_IP
               value: "true"
             - name: STORM_WAIT_RETRIES
-              value: "{{ .Values.thresh.wait.retries }}"
+              value: "{{ .Values.storm.thresh.wait.retries }}"
             - name: STORM_WAIT_DELAY
-              value: "{{ .Values.thresh.wait.delay }}"
+              value: "{{ .Values.storm.thresh.wait.delay }}"
             - name: STORM_WAIT_TIMEOUT
-              value: "{{ .Values.thresh.wait.timeout }}"
+              value: "{{ .Values.storm.thresh.wait.timeout }}"
             - name: ZOOKEEPER_SERVERS
               value: "{{ template "zookeeper.fullname" . }}"
             - name: STORM_ZOOKEEPER_PORT
-              value: "{{ .Values.kafka.zookeeper.service.port }}"
+              value: "2181"
             - name: NIMBUS_SEEDS
               value: "{{ .Release.Name }}-storm-nimbus"
             - name: METRIC_SPOUT_THREADS
-              value: "{{ .Values.thresh.spout.metricSpoutThreads }}"
+              value: "{{ .Values.storm.thresh.spout.metricSpoutThreads }}"
             - name: METRIC_SPOUT_TASKS
-              value: "{{ .Values.thresh.spout.metricSpoutTasks }}"
+              value: "{{ .Values.storm.thresh.spout.metricSpoutTasks }}"
             - name: KAFKA_URI
-              value: "{{ .Release.Name }}-kafka:{{ .Values.kafka.service.port }}"
+              value: "{{ .Release.Name }}-kafka:9092"
             - name: MYSQL_DB_HOST
               value: "{{ .Release.Name }}-mysql"
             - name: MYSQL_DB_PORT

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -334,21 +334,20 @@ storm:
     limits:
       memory: 4Gi
       cpu: 2000m
-
-thresh:
-  name: thresh
-  image:
-    repository: monasca/thresh
-    tag: master
-    pullPolicy: Always
-  secretSuffix: mysql-thresh-secret
-  spout:
-    metricSpoutThreads: 2
-    metricSpoutTasks: 2
-  wait:
-    retries: 24
-    delay: 5
-    timeout: 10
+  thresh:
+    name: thresh
+    image:
+      repository: monasca/thresh
+      tag: master
+      pullPolicy: Always
+    secretSuffix: mysql-thresh-secret
+    spout:
+      metricSpoutThreads: 2
+      metricSpoutTasks: 2
+    wait:
+      retries: 24
+      delay: 5
+      timeout: 10
 
 alarms:
   name: alarms

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -476,13 +476,6 @@ client:
 rbac:
   enabled: false
 
-kafka:
-  service:
-    port: 9092
-  zookeeper:
-    service:
-      port: 2181
-
 cleanup:
   name: cleanup
   image:

--- a/storm/Chart.yaml
+++ b/storm/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Apache Storm configured for Monasca
 name: storm
-version: 0.1.0
+version: 0.2.0

--- a/storm/templates/nimbus-deployment.yaml
+++ b/storm/templates/nimbus-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    component: "{{ .Values.storm.name }}-nimbus"
+    component: "{{ .Values.name }}-nimbus"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -14,17 +14,17 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
-        component: "{{ .Values.storm.name }}-nimbus"
+        component: "{{ .Values.name }}-nimbus"
     spec:
       containers:
-        - name: {{ template "name" . }}-{{ .Values.storm.name }}-nimbus
-          image: "{{ .Values.storm.image.repository }}:{{ .Values.storm.image.tag }}"
-          imagePullPolicy: {{ .Values.storm.image.pullPolicy }}
+        - name: {{ template "name" . }}-{{ .Values.name }}-nimbus
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["storm", "nimbus"]
           resources:
-{{ toYaml .Values.storm.nimbus_resources | indent 12 }}
+{{ toYaml .Values.nimbus_resources | indent 12 }}
           ports:
-            - containerPort: {{ .Values.storm.service.port }}
+            - containerPort: {{ .Values.service.port }}
               name: nimbus
           env:
             - name: STORM_HOSTNAME_FROM_IP
@@ -32,7 +32,7 @@ spec:
             - name: ZOOKEEPER_SERVERS
               value: "{{ .Release.Name }}-zookeeper"
             - name: STORM_ZOOKEEPER_PORT
-              value: "{{ .Values.kafka.zookeeper.service.port }}"
+              value: "2181"
             - name: NIMBUS_SEEDS
               value: "{{ template "storm.fullname" . }}-nimbus"
           volumeMounts:
@@ -40,7 +40,7 @@ spec:
               mountPath: /data
       volumes:
         - name: data
-        {{- if .Values.storm.persistence.enabled }}
+        {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ template "storm.fullname" . }}-nimbus
         {{- else }}

--- a/storm/templates/nimbus-pvc.yaml
+++ b/storm/templates/nimbus-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.storm.persistence.enabled }}
+{{- if .Values.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -6,19 +6,19 @@ metadata:
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    component: "{{ .Values.storm.name }}-nimbus"
+    component: "{{ .Values.name }}-nimbus"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-  {{- if .Values.storm.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.storm.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
   {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
   {{- end }}
 spec:
   accessModes:
-    - {{ .Values.storm.persistence.accessMode | quote }}
+    - {{ .Values.persistence.accessMode | quote }}
   resources:
     requests:
-      storage: {{ .Values.storm.persistence.size | quote }}
+      storage: {{ .Values.persistence.size | quote }}
 {{- end }}

--- a/storm/templates/nimbus-svc.yaml
+++ b/storm/templates/nimbus-svc.yaml
@@ -5,14 +5,14 @@ metadata:
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    component: "{{ .Values.storm.name }}-nimbus"
+    component: "{{ .Values.name }}-nimbus"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  type: {{ .Values.storm.service.type }}
+  type: {{ .Values.service.type }}
   ports:
   - name: nimbus
-    port: {{ .Values.storm.service.port }}
+    port: {{ .Values.service.port }}
   selector:
     app: {{ template "fullname" . }}
-    component: "{{ .Values.storm.name }}-nimbus"
+    component: "{{ .Values.name }}-nimbus"

--- a/storm/templates/supervisor-deployment.yaml
+++ b/storm/templates/supervisor-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    component: "{{ .Values.storm.name }}-supervisor"
+    component: "{{ .Values.name }}-supervisor"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -14,22 +14,22 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
-        component: "{{ .Values.storm.name }}-supervisor"
+        component: "{{ .Values.name }}-supervisor"
     spec:
       containers:
-        - name: {{ template "name" . }}-{{ .Values.storm.name }}
-          image: "{{ .Values.storm.image.repository }}:{{ .Values.storm.image.tag }}"
-          imagePullPolicy: {{ .Values.storm.image.pullPolicy }}
+        - name: {{ template "name" . }}-{{ .Values.name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["storm", "supervisor"]
           resources:
-{{ toYaml .Values.storm.supervisor_resources | indent 12 }}
+{{ toYaml .Values.supervisor_resources | indent 12 }}
           env:
             - name: STORM_HOSTNAME_FROM_IP
               value: "true"
             - name: ZOOKEEPER_SERVERS
               value: "{{ .Release.Name }}-zookeeper"
             - name: STORM_ZOOKEEPER_PORT
-              value: "{{ .Values.kafka.zookeeper.service.port }}"
+              value: "2181"
             - name: NIMBUS_SEEDS
               value: "{{ template "storm.fullname" . }}-nimbus"
             - name: METRIC_SPOUT_THREADS
@@ -37,7 +37,7 @@ spec:
             - name: METRIC_SPOUT_TASKS
               value: "{{ .Values.thresh.spout.metricSpoutTasks }}"
             - name: KAFKA_URI
-              value: "{{ .Release.Name }}-kafka:{{ .Values.kafka.service.port }}"
+              value: "{{ .Release.Name }}-kafka:9092"
             - name: MYSQL_DB_HOST
               value: "{{ .Release.Name }}-mysql"
             - name: MYSQL_DB_PORT

--- a/storm/values.yaml
+++ b/storm/values.yaml
@@ -1,43 +1,33 @@
-storm:
-  name: storm
-  image:
-    repository: monasca/storm
-    tag: 1.0.3
-    pullPolicy: Always
-  persistence:
-    storageClass: default
-    enabled: false
-    accessMode: ReadWriteOnce
-    size: 4Gi
-  service:
-    type: ClusterIP
-    port: 6627
-  nimbus_resources:
-    requests:
-      memory: 512Mi
-      cpu: 100m
-    limits:
-      memory: 2Gi
-      cpu: 500m
-  supervisor_resources:
-    requests:
-      memory: 2Gi
-      cpu: 250m
-    limits:
-      memory: 4Gi
-      cpu: 2000m
+name: storm
+image:
+  repository: monasca/storm
+  tag: 1.0.3
+  pullPolicy: Always
+persistence:
+  storageClass: default
+  enabled: false
+  accessMode: ReadWriteOnce
+  size: 4Gi
+service:
+  type: ClusterIP
+  port: 6627
+nimbus_resources:
+  requests:
+    memory: 512Mi
+    cpu: 100m
+  limits:
+    memory: 2Gi
+    cpu: 500m
+supervisor_resources:
+  requests:
+    memory: 2Gi
+    cpu: 250m
+  limits:
+    memory: 4Gi
+    cpu: 2000m
 
 thresh:
   secretSuffix: mysql-thresh-secret
   spout:
     metricSpoutThreads: 2
     metricSpoutTasks: 2
-
-# keep kafka in its own block since we want to reference+override it from
-# monasca/monasca and helm can't apply templates in values.yaml
-kafka:
-  service:
-    port: 9092
-  zookeeper:
-    service:
-      port: 2181


### PR DESCRIPTION
The storm chart incorrectly placed its values under a `storm` object,
resulting in it attempting to read from `storm.storm.xyz` values at
render time. This moves all the storm properties to the top level of
storm's values.yaml and treats thresh as a proper child object, so
`storm.xyz` in monasca's values.yaml will actually make sense.

Additionally, as the kafka and zookeeper port variables can't be
effectively shared between storm and monasca proper, they've now
just been hard-coded. Given that they're our containers anyway, this
doesn't seem like a large sacrifice.