### PR TITLE
Add hostname from kubernetes to every agent deploy

### DIFF
--- a/monasca-agent/Chart.yaml
+++ b/monasca-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Monasca-agent
 name: monasca-agent
-version: 0.2.0
+version: 0.2.1
 sources:
 - https://github.com/openstack/monasca-agent
 maintainers:

--- a/monasca-agent/templates/deployment.yaml
+++ b/monasca-agent/templates/deployment.yaml
@@ -22,6 +22,14 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           env:
+            - name: AGENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: AGENT_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: KUBERNETES_API
               value: "true"
             - name: KUBERNETES_API_TIMEOUT

--- a/monasca-agent/templates/deployment.yaml
+++ b/monasca-agent/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
               value: {{ .Values.log_level | quote }}
             - name: INSECURE
               value: {{ .Values.insecure | quote }}
+            - name: HOSTNAME_FROM_KUBERNETES
+              value: "true"
             {{- if .Values.namespace_annotations }}
             - name: KUBERNETES_NAMESPACE_ANNOTATIONS
               value: {{ .Values.namespace_annotations | quote}}

--- a/monasca/templates/agent-deployment.yaml
+++ b/monasca/templates/agent-deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: {{ .Values.agent.log_level | quote }}
             - name: INSECURE
               value: {{ .Values.agent.insecure | quote }}
+            - name: HOSTNAME_FROM_KUBERNETES
+              value: "true"
             {{- if .Values.agent.namespace_annotations }}
             - name: KUBERNETES_NAMESPACE_ANNOTATIONS
               value: {{ .Values.agent.namespace_annotations | quote}}

--- a/monasca/templates/agent-deployment.yaml
+++ b/monasca/templates/agent-deployment.yaml
@@ -23,6 +23,14 @@ spec:
           resources:
 {{ toYaml .Values.agent.resources | indent 12 }}
           env:
+            - name: AGENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: AGENT_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: KUBERNETES_API
               value: "true"
             - name: KUBERNETES_API_TIMEOUT


### PR DESCRIPTION
Ensures that we have connection the api and that our metrics do
not have pod name as hostname