### PR TITLE
Allow Threshold Engine to run without Storm

### DIFF
--- a/monasca/Chart.yaml
+++ b/monasca/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Monasca running in Kubernetes
 name: monasca
-version: 0.2.10
+version: 0.2.11
 sources:
 - https://wiki.openstack.org/wiki/Monasca
 maintainers:

--- a/monasca/Chart.yaml
+++ b/monasca/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Monasca running in Kubernetes
 name: monasca
-version: 0.2.11
+version: 0.2.12
 sources:
 - https://wiki.openstack.org/wiki/Monasca
 maintainers:

--- a/monasca/README.md
+++ b/monasca/README.md
@@ -439,6 +439,9 @@ Parameter | Description | Default
 Storm-specific options are documented in the
 [Storm chart](https://github.com/hpcloud-mon/monasca-helm/tree/master/storm).
 
+Storm is disabled and the Threshold Engine is run without Storm by default. To run the Threshold
+Engine with Storm, set storm.enabled to true and thresh.enabled to false.
+
 ### Tempest Tests
 
 Parameter | Description | Default

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -352,7 +352,7 @@ persister:
 
 storm:
   name: storm
-  enabled: true
+  enabled: false
   image:
     repository: monasca/storm
     tag: 1.0.3-1.0.4
@@ -383,7 +383,7 @@ storm:
     name: thresh
     image:
       repository: monasca/thresh
-      tag: master-20170512-171611
+      tag: master-20170726-195714
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -413,6 +413,42 @@ storm:
       retries: 24
       delay: 5
       timeout: 10
+
+thresh:
+  name: thresh
+  enabled: true
+  image:
+    repository: monasca/thresh
+    tag: master-20170726-195714
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 256m
+    limits:
+      memory: 512Mi
+      cpu: 1000m
+  secretSuffix: mysql-thresh-secret
+  spout:
+    metricSpoutThreads: 2
+    metricSpoutTasks: 2
+    eventSpoutThreads: 2
+    eventSpoutTasks: 2
+  bolt:
+    eventBoltThreads: 2
+    eventBoltTasks: 2
+    filteringBoltThreads: 2
+    filteringBoltTasks: 2
+    alarmCreationBoltThreads: 2
+    alarmCreationBoltTasks: 2
+    aggregationBoltThreads: 2
+    aggregationBoltTasks: 2
+    thresholdingBoltThreads: 2
+    thresholdingBoltTasks: 2
+  wait:
+    retries: 24
+    delay: 5
+    timeout: 10
 
 alarms:
   name: alarms


### PR DESCRIPTION
This will be the default, but Storm can be enabled. See monasca/README.md