### PR TITLE
Add in memcached container

### DIFF
--- a/monasca/Chart.yaml
+++ b/monasca/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Monasca running in Kubernetes
 name: monasca
-version: 0.2.15
+version: 0.2.16
 sources:
 - https://wiki.openstack.org/wiki/Monasca
 maintainers:

--- a/monasca/templates/_helpers.tpl
+++ b/monasca/templates/_helpers.tpl
@@ -142,3 +142,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "smoke_tests.fullname" -}}
 {{- printf "%s-%s" .Release.Name "smoke-tests" | trunc 63 -}}
 {{- end -}}
+
+{{/*
+Create a fully qualified memcached name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "memcached.fullname" -}}
+{{- printf "%s-%s" .Release.Name "memcached" | trunc 63 -}}
+{{- end -}}

--- a/monasca/templates/api-deployment.yaml
+++ b/monasca/templates/api-deployment.yaml
@@ -71,8 +71,8 @@ spec:
             - name: MYSQL_DB
               value: "mon"
             - name: MEMCACHED_URI
-            {{- if .Values.api.memcachedUril }}
-              value: "{{ .Values.api.memcachedUril }}"
+            {{- if .Values.api.memcachedUri }}
+              value: "{{ .Values.api.memcachedUri }}"
             {{- else if .Values.memcached.enabled }}
               value: "{{ template "memcached.fullname" . }}:{{ .Values.memcached.service.port | default "11211" }}"
             {{- else }}

--- a/monasca/templates/api-deployment.yaml
+++ b/monasca/templates/api-deployment.yaml
@@ -70,6 +70,14 @@ spec:
                   key: password
             - name: MYSQL_DB
               value: "mon"
+            - name: MEMCACHED_URI
+            {{- if .Values.api.memcachedUril }}
+              value: "{{ .Values.api.memcachedUril }}"
+            {{- else if .Values.memcached.enabled }}
+              value: "{{ template "memcached.fullname" . }}:{{ .Values.memcached.service.port | default "11211" }}"
+            {{- else }}
+              value: ""
+            {{- end }}
             - name: KEYSTONE_IDENTITY_URI
             {{- if .Values.keystone.enabled }}
               value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}"

--- a/monasca/templates/memcached-deployment.yaml
+++ b/monasca/templates/memcached-deployment.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.memcached.enabled }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "memcached.fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.memcached.name }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.memcached.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        component: "{{ .Values.memcached.name }}"
+    spec:
+      containers:
+      - name: {{ template "name" . }}-{{ .Values.memcached.name }}
+        image: "{{ .Values.memcached.image.repository }}:{{ .Values.memcached.image.tag }}"
+        imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.memcached.resources | indent 10 }}
+        ports:
+          - containerPort: 11211
+            name: memcached
+{{- end }}

--- a/monasca/templates/memcached-svc.yaml
+++ b/monasca/templates/memcached-svc.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.memcached.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.memcached.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "memcached.fullname" . }}
+spec:
+  type: {{ .Values.memcached.service.type | default "ClusterIP" }}
+  ports:
+    - name: memcached
+      port: {{ .Values.memcached.service.port | default "11211" }}
+      targetPort: memcached
+      {{- if .Values.memcached.service.node_port }}
+      nodePort: {{ .Values.memcached.service.node_port }}
+      {{- end }}
+  selector:
+    app: {{ template "fullname" . }}
+    component: "{{ .Values.memcached.name }}"
+{{- end}}

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -201,6 +201,25 @@ api:
   gunicorn_workers: 1
   mysql_disabled: false
 
+memcached:
+  name: memcached
+  enabled: true
+  image:
+    repository: memcached
+    tag: 1.5.0-alpine
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 11211
+  resources:
+    requests:
+      memory: 32Mi
+      cpu: 50m
+    limits:
+      memory: 64Mi
+      cpu: 100m
+
 forwarder:
   name: forwarder
   enabled: false


### PR DESCRIPTION
Add configuration to Monasca API to use memcached deployed through
this chart or external memcached

By default, deploy memcached