### PR TITLE
Add keystone-init chart

### DIFF
--- a/keystone-init/.helmignore
+++ b/keystone-init/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/keystone-init/Chart.yaml
+++ b/keystone-init/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Chart to initialize users in Keystone
+name: keystone-init
+version: 0.1.0

--- a/keystone-init/templates/_helpers.tpl
+++ b/keystone-init/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified cleanup name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cleanup.fullname" -}}
+{{- printf "%s-%s" .Release.Name "cleanup" | trunc 63 -}}
+{{- end -}}

--- a/keystone-init/templates/_keystone_env.tpl
+++ b/keystone-init/templates/_keystone_env.tpl
@@ -1,0 +1,57 @@
+{{- /* Generate a list of environment vars for Keystone Auth */}}
+{{- define "keystone_env" -}}
+- name: OS_AUTH_URL
+{{- if eq (kindOf .url) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .url.secret_name }}"
+      key: "{{ .url.secret_key | default "OS_AUTH_URL" }}"
+{{- else }}
+  value: "{{ .url }}"
+{{- end }}
+- name: OS_USERNAME
+{{- if eq (kindOf .username) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .username.secret_name }}"
+      key: "{{ .username.secret_key | default "OS_USERNAME" }}"
+{{- else }}
+  value: "{{ .username }}"
+{{- end }}
+- name: OS_PASSWORD
+{{- if eq (kindOf .password) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .password.secret_name }}"
+      key: "{{ .password.secret_key | default "OS_PASSWORD" }}"
+{{- else }}
+  value: "{{ .password }}"
+{{- end }}
+- name: OS_USER_DOMAIN_NAME
+{{- if eq (kindOf .user_domain_name) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .user_domain_name.secret_name }}"
+      key: "{{ .user_domain_name.secret_key | default "OS_USER_DOMAIN_NAME" }}"
+{{- else }}
+  value: "{{ .user_domain_name }}"
+{{- end }}
+- name: OS_PROJECT_NAME
+{{- if eq (kindOf .project_name) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .project_name.secret_name }}"
+      key: "{{ .project_name.secret_key | default "OS_PROJECT_NAME" }}"
+{{- else }}
+  value: "{{ .project_name }}"
+{{- end }}
+- name: OS_PROJECT_DOMAIN_NAME
+{{- if eq (kindOf .project_domain_name) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .project_domain_name.secret_name }}"
+      key: "{{ .project_domain_name.secret_key | default "OS_PROJECT_DOMAIN_NAME" }}"
+{{- else }}
+  value: "{{ .project_domain_name }}"
+{{- end }}
+{{- end -}}

--- a/keystone-init/templates/cleanup-pre-upgrade-hook.yaml
+++ b/keystone-init/templates/cleanup-pre-upgrade-hook.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # while not recommended, we add a random sequence to the end of the job name
+  # this job will attempt to delete itself when finished, but should it fail for
+  # some reason we don't want future upgrades to fail because of a name conflict
+  # (plus the future runs of this job will delete any previous iterations that
+  # failed to clean themselves up)
+  name: "{{ template "cleanup.fullname" . }}-job-{{ randAlphaNum 5 | lower }}"
+  labels:
+    app: {{ template "fullname" . }}
+    component: "{{ .Values.cleanup.name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        component: "{{ .Values.cleanup.name }}"
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: {{ template "name" . }}-{{ .Values.cleanup.name }}-job
+          image: "{{ .Values.cleanup.image.repository }}:{{ .Values.cleanup.image.tag }}"
+          imagePullPolicy: {{ .Values.cleanup.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.cleanup.resources | indent 12 }}
+          env:
+            - name: "WAIT_RETRIES"
+              value: "{{ .Values.cleanup.wait.retries }}"
+            - name: "WAIT_DELAY"
+              value: "{{ .Values.cleanup.wait.delay }}"
+            - name: "WAIT_TIMEOUT"
+              value: "{{ .Values.cleanup.wait.timeout }}"

--- a/keystone-init/templates/keystone-init-job.yaml
+++ b/keystone-init/templates/keystone-init-job.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "fullname" . }}-job
+  labels:
+    app: {{ template "fullname" . }}
+    component: "{{ .Values.keystone_init.name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        component: "{{ .Values.keystone_init.name }}"
+    spec:
+      restartPolicy: Never
+      volumes:
+        - name: preload-config
+          configMap:
+            name: "{{ template "fullname" . }}-preload"
+            items:
+              - key: preload.yml
+                path: preload.yml
+      containers:
+        - name: {{ template "fullname" . }}-job
+          image: "{{ .Values.keystone_init.image.repository }}:{{ .Values.keystone_init.image.tag }}"
+          imagePullPolicy: {{ .Values.keystone_init.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.keystone_init.resources | indent 12 }}
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.keystone_init.log_level }}
+            - name: KEYSTONE_TIMEOUT
+              value: "{{ .Values.keystone_init.timeout }}"
+            - name: KEYSTONE_VERIFY
+              value: "{{ .Values.keystone_init.verify }}"
+            - name: KEYSTONE_CERT
+              value: "{{ .Values.keystone_init.cert }}"
+{{ include "keystone_env" .Values.keystone_init.auth | indent 12 }}
+          volumeMounts:
+            - name: preload-config
+              mountPath: /preload.yml
+              subPath: preload.yml

--- a/keystone-init/templates/keystone-preload-configmap.yaml
+++ b/keystone-init/templates/keystone-preload-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ template "fullname" . }}-preload"
+  labels:
+    app: "{{ template "fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  preload.yml: |
+{{ toYaml .Values.keystone_init.preload | indent 4 }}

--- a/keystone-init/values.yaml
+++ b/keystone-init/values.yaml
@@ -1,0 +1,97 @@
+# Default values for keystone-init.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+keystone_init:
+  name: keystone-init
+
+  image:
+    repository: monasca/keystone-init
+    tag: 1.0.1
+    pullPolicy: IfNotPresent
+
+  # general options for the init job
+  log_level: INFO # python logging level
+  timeout: "10" # timeout in seconds
+  verify: "true" # if "true", verify SSL
+  cert: '' # cert to override if desired (must be mounted as configmap)
+
+  # keystone authentication for this component
+  # note that these options allow the init container to connect to keystone and
+  # the referenced account must already exist
+  # each parameter may either be specified directly as a string OR reference a
+  # secret
+  # example:
+  #   # plaintext (will be stored in Helm's ConfigMap)
+  #   password: 'some-plaintext-password'
+  #
+  #   # secret ref
+  #   password:
+  #     secret_name: some-secret-name
+  #     # key is optional, will default to `OS_`-style variables
+  #     secret_key: some-key
+  auth:
+    url: 'http://keystone:5000'
+    username: "admin"
+    password: "s3cr3t"
+    user_domain_name: Default
+    project_name: 'admin'
+    project_domain_name: Default
+
+  # specify domains, projects, roles, and users to create
+  preload: # empty by default
+    # named domains, the key name will be used to look up keystone domain name
+    domains:
+      # note that `default` is special and refers directly to the ID `default`,
+      # not the name `Default`
+      default:
+        # a list of project names that must exist (will be created)
+        projects: []
+
+        # a list of role names that must exist (will be created)
+        roles: []
+
+        # a list of user objects that must exist
+        # example:
+        # users:
+        #   - username: some-user
+        #     project: some-project # will be created if it does not exist
+        #     roles: # will also be created automatically
+        #       - a
+        #       - b
+        #       - c
+        #     # if desired, create a secret (optional):
+        #     secret: some-secret-name
+        #     # alternatively, specify a namespace and name
+        #     secret: some-namespace/some-secret-name
+        #     # or even:
+        #     secret:
+        #       namespace: some-namespace
+        #       name: some-secret-name
+        users: []
+
+  # container resource limits and requests
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+cleanup:
+  name: cleanup
+  image:
+    repository: monasca/job-cleanup
+    tag: 1.1.2
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 200m
+    limits:
+      memory: 128Mi
+      cpu: 250m
+  wait:
+    retries: "24"
+    delay: "5.0"
+    timeout: "10"


### PR DESCRIPTION
This adds a dedicated `keystone-init` chart which can be used to safely initialize Keystone accounts while keeping passwords relatively secure. Passwords are randomly generated at first run (or upgrade) and written to chart-configurable Kubernetes secrets. The job is automatically cleaned up before subsequent upgrades using the cleanup job.

This will eventually replace keystone bootstrapping in the main `monasca` chart.