### PR TITLE
Various fixes to keystone-init

### DIFF
--- a/keystone-init/Chart.yaml
+++ b/keystone-init/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Chart to initialize users in Keystone
 name: keystone-init
-version: 0.1.0
+version: 0.1.1

--- a/keystone-init/templates/_keystone_env.tpl
+++ b/keystone-init/templates/_keystone_env.tpl
@@ -9,6 +9,10 @@
 {{- else }}
   value: "{{ .url }}"
 {{- end }}
+{{- if .api_version }}
+- name: OS_IDENTITY_API_VERSION
+  value: "{{ .api_version }}"
+{{- end }}
 - name: OS_USERNAME
 {{- if eq (kindOf .username) "map" }}
   valueFrom:

--- a/keystone-init/templates/keystone-init-job.yaml
+++ b/keystone-init/templates/keystone-init-job.yaml
@@ -9,13 +9,14 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  activeDeadlineSections: {{ .Values.keystone_init.deadline }}
   template:
     metadata:
       labels:
         app: {{ template "fullname" . }}
         component: "{{ .Values.keystone_init.name }}"
     spec:
-      restartPolicy: Never
+      restartPolicy: OnFailure
       volumes:
         - name: preload-config
           configMap:

--- a/keystone-init/values.yaml
+++ b/keystone-init/values.yaml
@@ -9,6 +9,9 @@ keystone_init:
     tag: 1.0.1
     pullPolicy: IfNotPresent
 
+  # job completion deadline in seconds
+  deadline: 300
+
   # general options for the init job
   log_level: INFO # python logging level
   timeout: "10" # timeout in seconds


### PR DESCRIPTION
- support overriding OS_IDENTITY_API_VERSION
 - set job container restartPolicy to OnFailure (prevents job spam)
 - add a completion deadline for the job (5min default)
 - update to v1.0.1 of the init container to add tini init