### PR TITLE
Improve keystone-init's template

### DIFF
--- a/keystone-init/templates/keystone-init-job.yaml
+++ b/keystone-init/templates/keystone-init-job.yaml
@@ -39,7 +39,7 @@ spec:
               value: "{{ .Values.keystone_init.verify }}"
             - name: KEYSTONE_CERT
               value: "{{ .Values.keystone_init.cert }}"
-{{ include "keystone_env" .Values.keystone_init.auth | indent 12 }}
+{{ include "keystone_init_keystone_env" .Values.keystone_init.auth | indent 12 }}
           volumeMounts:
             - name: preload-config
               mountPath: /preload.yml


### PR DESCRIPTION
This adds several minor improvements to keystone-init's
_keystone_env.tpl:

 - prefix the template name with the chart name per the Helm
   recommendations [1]
 - add a new `secret_env` function to allow other templates to pull a
   single secret (with string fallback) into an `env` value field with
   less boilerplate
 - make several v3-specific parameters (e.g. project_name) optional
 - add several (optional) parameters for keystone v2, e.g. tenant_name

These aren't necessarily needed for the keystone-init chart itself,
but may be useful for charts (e.g. monasca) that will consume
keystone-init.

[1] https://github.com/kubernetes/helm/blob/master/docs/chart_template_guide/named_templates.md#declaring-and-using-templates-with-define-and-template