### PR TITLE
Standardize Keystone variables

### DIFF
--- a/monasca/Chart.yaml
+++ b/monasca/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Monasca running in Kubernetes
 name: monasca
-version: 0.2.17
+version: 0.3.0
 sources:
 - https://wiki.openstack.org/wiki/Monasca
 maintainers:

--- a/monasca/README.md
+++ b/monasca/README.md
@@ -178,11 +178,11 @@ Parameter | Description | Default
 `agent.plugins.config_files` | List of plugin yamls to be used with the agent | ``
 `agent.insecure` | Insecure connection to Keystone and Monasca API | `False`
 `agent.log_level` | Log level of agent log files | `WARN`
-`agent.keystone.os_username` | Agent Keystone username | `mini-mon`
-`agent.keystone.os_user_domain_name` | Agent Keystone user domain | `Default`
-`agent.keystone.os_password` | Agent Keystone password | `password`
-`agent.keystone.os_project_name` | Agent Keystone project name | `mini-mon`
-`agent.keystone.os_project_domain_name` | Agent Keystone project domain | `Default`
+`agent.keystone.username` | Agent Keystone username | `mini-mon`
+`agent.keystone.user_domain_name` | Agent Keystone user domain | `Default`
+`agent.keystone.password` | Agent Keystone password | `password`
+`agent.keystone.project_name` | Agent Keystone project name | `mini-mon`
+`agent.keystone.project_domain_name` | Agent Keystone project domain | `Default`
 `agent.namespace_annotations` | Namespace annotations to set as metrics dimensions | ``
 `agent.prometheus.auto_detect_pod_endpoints` | Autodetect Prometheus endpoints for scraping by pods | `true`
 `agent.prometheus.auto_detect_service_endpoints` | Autodetect Prometheus endpoints for scraping by services | `true`
@@ -225,11 +225,11 @@ Parameter | Description | Default
 `alarms.wait.retries` | Number of attempts to create alarms before giving up | `24`
 `alarms.wait.delay` | Seconds to wait between retries | `5`
 `alarms.wait.timeout` | Attempt connection timeout in seconds | `10`
-`alarms.keystone.os_username` | Monasca Keystone user | `mini-mon`
-`alarms.keystone.os_user_domain_name` | Monasca Keystone user domain | `Default`
-`alarms.keystone.os_password` | Monasca Keystone password | `password`
-`alarms.keystone.os_project_name` | Monasca Keystone project name | `mini-mon`
-`alarms.keystone.os_project_domain_name` | Monasca Keystone project domain | `Default`
+`alarms.keystone.username` | Monasca Keystone user | `mini-mon`
+`alarms.keystone.user_domain_name` | Monasca Keystone user domain | `Default`
+`alarms.keystone.password` | Monasca Keystone password | `password`
+`alarms.keystone.project_name` | Monasca Keystone project name | `mini-mon`
+`alarms.keystone.project_domain_name` | Monasca Keystone project domain | `Default`
 
 ### API
 
@@ -278,11 +278,11 @@ Parameter | Description | Default
 `client.image.repository` | Client container image repository | `rbrndt/python-monascaclient`
 `client.image.tag` | Client container image tag | `1.6.0`
 `client.image.pullPolicy` | Client container image pull policy | `IfNotPresent`
-`client.keystone.os_username` | Keystone user | `mini-mon`
-`client.keystone.os_user_domain_name` | Keystone user domain | `Default`
-`client.keystone.os_password` | Keystone password | `password`
-`client.keystone.os_project_name` | Keystone project name | `mini-mon`
-`client.keystone.os_project_domain_name` | Keystone project domain | `Default`
+`client.keystone.username` | Keystone user | `mini-mon`
+`client.keystone.user_domain_name` | Keystone user domain | `Default`
+`client.keystone.password` | Keystone password | `password`
+`client.keystone.project_name` | Keystone project name | `mini-mon`
+`client.keystone.project_domain_name` | Keystone project domain | `Default`
 
 ### Forwarder
 
@@ -535,6 +535,6 @@ Parameter | Description | Default
 `smoke_tests.image.repository` | Smoke Test container image repository | `monasca/smoke-tests`
 `smoke_tests.image.tag` | Smoke Test container image tag | `1.0.0`
 `smoke_tests.image.pullPolicy` | Smoke Test container image pull policy | `IfNotPresent`
-`smoke_tests.keystone.os_username`| Keystone User Name | `mini-mon`
-`smoke_tests.keystone.os_password`| Keystone User Tenant Name | `mini-mon`
-`smoke_tests.keystone.os_tenant_name` | Keystone Domain name | `Default`
+`smoke_tests.keystone.username`| Keystone User Name | `mini-mon`
+`smoke_tests.keystone.password`| Keystone User Tenant Name | `mini-mon`
+`smoke_tests.keystone.tenant_name` | Keystone Domain name | `Default`

--- a/monasca/templates/_keystone_env.tpl
+++ b/monasca/templates/_keystone_env.tpl
@@ -1,0 +1,133 @@
+{{- /*
+Read a single optional secret or string from values into an `env` `value:` or
+`valueFrom:`, depending on the user-defined content of the value.
+
+Example:
+  - name: OS_AUTH_URL
+    {{ template "monasca_secret_env" .Values.auth.url }}
+
+Note that unlike monasca_keystone_env, secret_key can not have any default
+values.
+
+Make sure to change the name of this template when copying to keep it unique,
+e.g. chart_name_secret_env.
+*/}}
+{{- define "monasca_secret_env" }}
+{{- if eq (kindOf .) "map" }}
+valueFrom:
+  secretKeyRef:
+    name: "{{ .secret_name }}"
+    key: "{{ .secret_key }}"
+{{- else }}
+value: "{{ . }}"
+{{- end }}
+{{- end }}
+
+{{- /*
+Generate a list of environment vars for Keystone Auth
+
+Example:
+  env:
+{{ include "monasca_keystone_env" .Values.my_pod.auth | indent 4 }}
+
+(indent level should be adjusted as necessary)
+
+Make sure to change the name of this template when copying to keep it unique,
+e.g. chart_name_keystone_env.
+
+Note that monasca_secret_env is not used here because we want to provide
+default key names.
+
+Note: this template does NOT set OS_AUTH_URL, since we may need to reference our
+internal Keystone URL and Helm cannot pass more than one variable at once.
+*/}}
+{{- define "monasca_keystone_env" -}}
+{{- if .api_version }}
+- name: OS_IDENTITY_API_VERSION
+  value: "{{ .api_version }}"
+{{- end }}
+- name: OS_USERNAME
+{{- if eq (kindOf .username) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .username.secret_name }}"
+      key: "{{ .username.secret_key | default "OS_USERNAME" }}"
+{{- else }}
+  value: "{{ .username }}"
+{{- end }}
+- name: OS_PASSWORD
+{{- if eq (kindOf .password) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .password.secret_name }}"
+      key: "{{ .password.secret_key | default "OS_PASSWORD" }}"
+{{- else }}
+  value: "{{ .password }}"
+{{- end }}
+{{- if .user_domain_name }}
+- name: OS_USER_DOMAIN_NAME
+{{- if eq (kindOf .user_domain_name) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .user_domain_name.secret_name }}"
+      key: "{{ .user_domain_name.secret_key | default "OS_USER_DOMAIN_NAME" }}"
+{{- else }}
+  value: "{{ .user_domain_name }}"
+{{- end }}
+{{- end }}
+{{- if .project_name }}
+- name: OS_PROJECT_NAME
+{{- if eq (kindOf .project_name) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .project_name.secret_name }}"
+      key: "{{ .project_name.secret_key | default "OS_PROJECT_NAME" }}"
+{{- else }}
+  value: "{{ .project_name }}"
+{{- end }}
+{{- end }}
+{{- if .project_domain_name }}
+- name: OS_PROJECT_DOMAIN_NAME
+{{- if eq (kindOf .project_domain_name) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .project_domain_name.secret_name }}"
+      key: "{{ .project_domain_name.secret_key | default "OS_PROJECT_DOMAIN_NAME" }}"
+{{- else }}
+  value: "{{ .project_domain_name }}"
+{{- end }}
+{{- end }}
+{{- if .tenant_name }}
+- name: OS_TENANT_NAME
+{{- if eq (kindOf .tenant_name) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .tenant_name.secret_name }}"
+      key: "{{ .tenant_name.secret_key | default "OS_TENANT_NAME" }}"
+{{- else }}
+  value: "{{ .tenant_name }}"
+{{- end }}
+{{- end }}
+{{- if .tenant_id }}
+- name: OS_TENANT_ID
+{{- if eq (kindOf .tenant_id) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .tenant_id.secret_name }}"
+      key: "{{ .tenant_id.secret_key | default "OS_TENANT_ID" }}"
+{{- else }}
+  value: "{{ .tenant_id }}"
+{{- end }}
+{{- end }}
+{{- if .region_name }}
+- name: OS_REGION_NAME
+{{- if eq (kindOf .region_name) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .region_name.secret_name }}"
+      key: "{{ .region_name.secret_key | default "OS_REGION_NAME" }}"
+{{- else }}
+  value: "{{ .region_name }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/monasca/templates/agent-daemonset.yaml
+++ b/monasca/templates/agent-daemonset.yaml
@@ -23,6 +23,22 @@ spec:
           resources:
 {{ toYaml .Values.agent.resources | indent 12 }}
           env:
+            - name: OS_AUTH_URL
+            {{- if .Values.agent.keystone.url }}
+            {{- if eq (kindOf .Values.agent.keystone.url) "map" }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.agent.keystone.url.secret_name }}"
+                  key: "{{ .Values.agent.keystone.url.secret_key | default "OS_AUTH_URL" }}"
+            {{- else }}
+              value: "{{ .Values.agent.keystone.url }}"
+            {{- end }}
+            {{- else if .Values.keystone.override.public_url }}
+              value: "{{ .Values.keystone.override.public_url }}/v3"
+            {{- else }}
+              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
+            {{- end }}
+{{ include "monasca_keystone_env" .Values.agent.keystone | indent 12 }}
             - name: AGENT_POD_NAME
               valueFrom:
                 fieldRef:
@@ -49,22 +65,6 @@ spec:
               value: {{ .Values.agent.cadvisor.enabled | quote }}
             - name: CADVISOR_TIMEOUT
               value: {{ .Values.agent.cadvisor.timeout | quote }}
-            - name: OS_AUTH_URL
-            {{- if .Values.keystone.enabled }}
-              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
-            {{- else }}
-              value: "{{ .Values.keystone.override.public_url }}/v3"
-            {{- end }}
-            - name: OS_USERNAME
-              value: {{ .Values.agent.keystone.os_username | quote }}
-            - name: OS_USER_DOMAIN_NAME
-              value: {{ .Values.agent.keystone.os_user_domain_name | quote }}
-            - name: OS_PASSWORD
-              value: {{ .Values.agent.keystone.os_password | quote }}
-            - name: OS_PROJECT_NAME
-              value: {{ .Values.agent.keystone.os_project_name | quote }}
-            - name: OS_PROJECT_DOMAIN_NAME
-              value: {{ .Values.agent.keystone.os_project_domain_name | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.agent.log_level | quote }}
             - name: HOSTNAME_FROM_KUBERNETES
@@ -83,6 +83,22 @@ spec:
           resources:
 {{ toYaml .Values.agent.resources | indent 12 }}
           env:
+            - name: OS_AUTH_URL
+            {{- if .Values.agent.keystone.url }}
+            {{- if eq (kindOf .Values.agent.keystone.url) "map" }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.agent.keystone.url.secret_name }}"
+                  key: "{{ .Values.agent.keystone.url.secret_key | default "OS_AUTH_URL" }}"
+            {{- else }}
+              value: "{{ .Values.agent.keystone.url }}"
+            {{- end }}
+            {{- else if .Values.keystone.override.public_url }}
+              value: "{{ .Values.keystone.override.public_url }}/v3"
+            {{- else }}
+              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
+            {{- end }}
+{{ include "monasca_keystone_env" .Values.agent.keystone | indent 12 }}
             - name: AGENT_POD_NAME
               valueFrom:
                 fieldRef:
@@ -91,22 +107,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: OS_AUTH_URL
-            {{- if .Values.keystone.enabled }}
-              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
-            {{- else }}
-              value: "{{ .Values.keystone.override.public_url }}/v3"
-            {{- end }}
-            - name: OS_USERNAME
-              value: {{ .Values.agent.keystone.os_username | quote }}
-            - name: OS_USER_DOMAIN_NAME
-              value: {{ .Values.agent.keystone.os_user_domain_name | quote }}
-            - name: OS_PASSWORD
-              value: {{ .Values.agent.keystone.os_password | quote }}
-            - name: OS_PROJECT_NAME
-              value: {{ .Values.agent.keystone.os_project_name | quote }}
-            - name: OS_PROJECT_DOMAIN_NAME
-              value: {{ .Values.agent.keystone.os_project_domain_name | quote }}
             - name: MONASCA_URL
               value: "http://{{ template "api.fullname" . }}:{{ .Values.api.service.port }}/v2.0"
             - name: LOG_LEVEL

--- a/monasca/templates/agent-deployment.yaml
+++ b/monasca/templates/agent-deployment.yaml
@@ -23,6 +23,22 @@ spec:
           resources:
 {{ toYaml .Values.agent.resources | indent 12 }}
           env:
+            - name: OS_AUTH_URL
+            {{- if .Values.agent.keystone.url }}
+            {{- if eq (kindOf .Values.agent.keystone.url) "map" }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.agent.keystone.url.secret_name }}"
+                  key: "{{ .Values.agent.keystone.url.secret_key | default "OS_AUTH_URL" }}"
+            {{- else }}
+              value: "{{ .Values.agent.keystone.url }}"
+            {{- end }}
+            {{- else if .Values.keystone.override.public_url }}
+              value: "{{ .Values.keystone.override.public_url }}/v3"
+            {{- else }}
+              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
+            {{- end }}
+{{ include "monasca_keystone_env" .Values.agent.keystone | indent 12 }}
             - name: AGENT_POD_NAME
               valueFrom:
                 fieldRef:
@@ -45,22 +61,6 @@ spec:
               value: service
             - name: PROMETHEUS_KUBERNETES_LABELS
               value: {{ .Values.agent.prometheus.kubernetes_labels | quote }}
-            - name: OS_AUTH_URL
-            {{- if .Values.keystone.enabled }}
-              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
-            {{- else }}
-              value: "{{ .Values.keystone.override.public_url }}/v3"
-            {{- end }}
-            - name: OS_USERNAME
-              value: {{ .Values.agent.keystone.os_username | quote }}
-            - name: OS_USER_DOMAIN_NAME
-              value: {{ .Values.agent.keystone.os_user_domain_name | quote }}
-            - name: OS_PASSWORD
-              value: {{ .Values.agent.keystone.os_password | quote }}
-            - name: OS_PROJECT_NAME
-              value: {{ .Values.agent.keystone.os_project_name | quote }}
-            - name: OS_PROJECT_DOMAIN_NAME
-              value: {{ .Values.agent.keystone.os_project_domain_name | quote }}
             - name: MONASCA_URL
               value: "http://{{ template "api.fullname" . }}:{{ .Values.api.service.port }}/v2.0"
             - name: LOG_LEVEL
@@ -101,21 +101,21 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: OS_AUTH_URL
-            {{- if .Values.keystone.enabled }}
-              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
+            {{- if .Values.agent.keystone.url }}
+            {{- if eq (kindOf .Values.agent.keystone.url) "map" }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.agent.keystone.url.secret_name }}"
+                  key: "{{ .Values.agent.keystone.url.secret_key | default "OS_AUTH_URL" }}"
             {{- else }}
-              value: "{{ .Values.keystone.override.public_url }}/v3"
+              value: "{{ .Values.agent.keystone.url }}"
             {{- end }}
-            - name: OS_USERNAME
-              value: {{ .Values.agent.keystone.os_username | quote }}
-            - name: OS_USER_DOMAIN_NAME
-              value: {{ .Values.agent.keystone.os_user_domain_name | quote }}
-            - name: OS_PASSWORD
-              value: {{ .Values.agent.keystone.os_password | quote }}
-            - name: OS_PROJECT_NAME
-              value: {{ .Values.agent.keystone.os_project_name | quote }}
-            - name: OS_PROJECT_DOMAIN_NAME
-              value: {{ .Values.agent.keystone.os_project_domain_name | quote }}
+            {{- else if .Values.keystone.override.public_url }}
+              value: "{{ .Values.keystone.override.public_url }}/v3"
+            {{- else }}
+              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
+            {{- end }}
+{{ include "monasca_keystone_env" .Values.agent.keystone | indent 12 }}
             - name: MONASCA_URL
               value: "http://{{ template "api.fullname" . }}:{{ .Values.api.service.port }}/v2.0"
             - name: LOG_LEVEL

--- a/monasca/templates/alarms-init-job.yaml
+++ b/monasca/templates/alarms-init-job.yaml
@@ -24,28 +24,28 @@ spec:
           resources:
 {{ toYaml .Values.alarms.resources | indent 12 }}
           env:
+            - name: OS_AUTH_URL
+            {{- if .Values.client.keystone.url }}
+            {{- if eq (kindOf .Values.client.keystone.url) "map" }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.client.keystone.url.secret_name }}"
+                  key: "{{ .Values.client.keystone.url.secret_key | default "OS_AUTH_URL" }}"
+            {{- else }}
+              value: "{{ .Values.client.keystone.url }}"
+            {{- end }}
+            {{- else if .Values.keystone.override.public_url }}
+              value: "{{ .Values.keystone.override.public_url }}/v3"
+            {{- else }}
+              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
+            {{- end }}
+{{ include "monasca_keystone_env" .Values.client.keystone | indent 12 }}
             - name: MONASCA_WAIT_FOR_API
               value: "{{ .Values.alarms.wait.enabled }}"
             - name: MONASCA_API_WAIT_RETRIES
               value: "{{ .Values.alarms.wait.retries }}"
             - name: MONASCA_API_WAIT_DELAY
               value: "{{ .Values.alarms.wait.delay }}"
-            - name: OS_PASSWORD
-              value: "{{ .Values.alarms.keystone.os_password }}"
-            - name: OS_USERNAME
-              value: "{{ .Values.alarms.keystone.os_username }}"
-            - name: OS_PROJECT_NAME
-              value: "{{ .Values.alarms.keystone.os_project_name }}"
-            - name: OS_USER_DOMAIN_NAME
-              value: "{{ .Values.alarms.keystone.os_user_domain_name }}"
-            - name: OS_PROJECT_DOMAIN_NAME
-              value: "{{ .Values.alarms.keystone.os_project_domain_name }}"
-            - name: OS_AUTH_URL
-            {{- if .Values.keystone.enabled }}
-              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
-            {{- else }}
-              value: "{{ .Values.keystone.override.public_url }}/v3"
-            {{- end }}
             {{- if .Values.alarms.notification_name }}
             - name: NOTIFICATION_NAME
               value: "{{ .Values.alarms.notification_name }}"

--- a/monasca/templates/api-deployment.yaml
+++ b/monasca/templates/api-deployment.yaml
@@ -79,31 +79,27 @@ spec:
               value: ""
             {{- end }}
             - name: KEYSTONE_IDENTITY_URI
-            {{- if .Values.keystone.enabled }}
-              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}"
-            {{- else }}
+            {{- if .Values.api.keystone.identity_url }}
+{{- include "monasca_secret_env" .Values.api.keystone.identity_url | indent 14 }}
+            {{- else if .Values.keystone.override.public_url }}
               value: "{{ .Values.keystone.override.public_url }}"
+            {{- else }}
+              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}"
             {{- end }}
             - name: KEYSTONE_AUTH_URI
-            {{- if .Values.keystone.enabled }}
-              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.admin_port }}"
-            {{- else }}
+            {{- if .Values.api.keystone.auth_url }}
+{{- include "monasca_secret_env" .Values.api.keystone.auth_url | indent 14 }}
+            {{- else if .Values.keystone.override.admin_url }}
               value: "{{ .Values.keystone.override.admin_url }}"
+            {{- else }}
+              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.admin_port }}"
             {{- end }}
             - name: KEYSTONE_ADMIN_USER
-              value: {{ .Values.api.keystone.admin_user | quote }}
-            {{- if .Values.api.keystone.admin_password_secret }}
+{{- include "monasca_secret_env" .Values.api.keystone.username | indent 14 }}
             - name: KEYSTONE_ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.api.keystone.admin_password_secret }}"
-                  key: "{{ .Values.api.keystone.admin_password_secret_key | default .Values.api.keystone.admin_password_secret }}"
-            {{- else if .Values.api.keystone.admin_password }}
-            - name: KEYSTONE_ADMIN_PASSWORD
-              value: {{ .Values.api.keystone.admin_password | quote }}
-            {{- end }}
+{{- include "monasca_secret_env" .Values.api.keystone.password | indent 14 }}
             - name: KEYSTONE_ADMIN_TENANT
-              value: {{ .Values.api.keystone.admin_tenant | quote }}
+{{- include "monasca_secret_env" .Values.api.keystone.tenant_name | indent 14 }}
             {{- if .Values.api.auth_disabled }}
             - name: API_AUTH_DISABLED
               value: "true"

--- a/monasca/templates/client-deployment.yaml
+++ b/monasca/templates/client-deployment.yaml
@@ -28,29 +28,21 @@ spec:
 {{ toYaml .Values.client.resources | indent 12 }}
           env:
             - name: OS_AUTH_URL
-            {{- if .Values.keystone.enabled }}
-              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
-            {{- else }}
-              value: "{{ .Values.keystone.override.public_url }}/v3"
-            {{- end }}
-            - name: OS_USERNAME
-              value: {{ .Values.client.keystone.os_username | quote }}
-            - name: OS_USER_DOMAIN_NAME
-              value: {{ .Values.client.keystone.os_user_domain_name | quote }}
-            {{- if .Values.client.keystone.os_password_secret }}
-            - name: OS_PASSWORD
+            {{- if .Values.client.keystone.url }}
+            {{- if eq (kindOf .Values.client.keystone.url) "map" }}
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.client.keystone.os_password_secret }}"
-                  key: "{{ .Values.client.keystone.os_password_secret_key | default .Values.client.keystone.os_password_secret }}"
-            {{- else if .Values.client.keystone.os_password }}
-            - name: OS_PASSWORD
-              value: {{ .Values.client.keystone.os_password | quote }}
+                  name: "{{ .Values.client.keystone.url.secret_name }}"
+                  key: "{{ .Values.client.keystone.url.secret_key | default "OS_AUTH_URL" }}"
+            {{- else }}
+              value: "{{ .Values.client.keystone.url }}"
             {{- end }}
-            - name: OS_PROJECT_NAME
-              value: {{ .Values.client.keystone.os_project_name | quote }}
-            - name: OS_PROJECT_DOMAIN_NAME
-              value: {{ .Values.client.keystone.os_project_domain_name | quote }}
+            {{- else if .Values.keystone.override.public_url }}
+              value: "{{ .Values.keystone.override.public_url }}/v3"
+            {{- else }}
+              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
+            {{- end }}
+{{ include "monasca_keystone_env" .Values.client.keystone | indent 12 }}
             - name: MONASCA_URL
               value: "http://{{ template "api.fullname" . }}:{{ .Values.api.service.port }}/v2.0"
 {{- end }}

--- a/monasca/templates/smoke-test-pod.yaml
+++ b/monasca/templates/smoke-test-pod.yaml
@@ -23,20 +23,22 @@ spec:
         - containerPort: 8080
           name: smoke-tests
       env:
-        - name: OS_PASSWORD
-          value: "{{ .Values.smoke_tests.keystone.os_password }}"
-        - name: OS_USERNAME
-          value: "{{ .Values.smoke_tests.keystone.os_username }}"
         - name: OS_AUTH_URL
-        {{- if .Values.keystone.enabled }}
-          value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.admin_port }}/v3"
+        {{- if .Values.smoke_tests.keystone.url }}
+        {{- if eq (kindOf .Values.smoke_tests.keystone.url) "map" }}
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.smoke_tests.keystone.url.secret_name }}"
+              key: "{{ .Values.smoke_tests.keystone.url.secret_key | default "OS_AUTH_URL" }}"
         {{- else }}
-          value: "{{ .Values.keystone.override.admin_url }}/v3"
+          value: "{{ .Values.smoke_tests.keystone.url }}"
         {{- end }}
-        - name: OS_TENANT_NAME
-          value: "{{ .Values.smoke_tests.keystone.os_tenant_name }}"
-        - name: OS_DOMAIN_NAME
-          value: "{{ .Values.smoke_tests.keystone.os_domain_name }}"
+        {{- else if .Values.keystone.override.public_url }}
+          value: "{{ .Values.keystone.override.public_url }}/v3"
+        {{- else }}
+          value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
+        {{- end }}
+{{ include "monasca_keystone_env" .Values.smoke_tests.keystone | indent 8 }}
         - name: MONASCA_URL
           value:  "http://{{ template "api.fullname" . }}:{{ .Values.api.service.port }}"
 {{- end }}

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -120,11 +120,11 @@ agent:
   log_level: WARN
   insecure: False
   keystone:
-    os_username: mini-mon
-    os_user_domain_name: Default
-    os_password: password
-    os_project_name: mini-mon
-    os_project_domain_name: Default
+    username: mini-mon
+    user_domain_name: Default
+    password: password
+    project_name: mini-mon
+    project_domain_name: Default
   prometheus:
     auto_detect_pod_endpoints: true
     auto_detect_service_endpoints: true
@@ -159,9 +159,11 @@ api:
     pullPolicy: IfNotPresent
   replicaCount: 1
   keystone:
-    admin_password: secretadmin
-    admin_user: admin
-    admin_tenant: admin
+    username: admin
+    password: secretadmin
+    tenant_name: admin
+    identity_url: ''
+    auth_url: ''
   influxdb:
     user: mon_api
     password: password
@@ -272,8 +274,8 @@ keystone:
   name: keystone
   enabled: true
   override:
-    public_url: http://keystone:35357
-    admin_url: http://keystone:5000
+    public_url: ''
+    admin_url: ''
   bootstrap:
     user: admin
     password: secretadmin
@@ -493,11 +495,11 @@ alarms:
     retries: 24
     delay: 5
   keystone:
-    os_username: mini-mon
-    os_user_domain_name: Default
-    os_password: password
-    os_project_name: mini-mon
-    os_project_domain_name: Default
+    username: mini-mon
+    user_domain_name: Default
+    password: password
+    project_name: mini-mon
+    project_domain_name: Default
   definitions_configuration:
      definitions.yml.j2: |
       notifications:
@@ -606,11 +608,11 @@ client:
       memory: 128Mi
       cpu: 500m
   keystone:
-    os_username: mini-mon
-    os_user_domain_name: Default
-    os_password: password
-    os_project_name: mini-mon
-    os_project_domain_name: Default
+    username: mini-mon
+    user_domain_name: Default
+    password: password
+    project_name: mini-mon
+    project_domain_name: Default
 
 rbac:
   enabled: false
@@ -1539,7 +1541,7 @@ smoke_tests:
       memory: 128Mi
       cpu: 500m
   keystone:
-    os_username: mini-mon
-    os_password: password
-    os_tenant_name: mini-mon
-    os_domain_name: Default
+    username: mini-mon
+    password: password
+    tenant_name: mini-mon
+    domain_name: Default


### PR DESCRIPTION
This commit standardizes Keystone variable handling throughout the
monasca chart, supporting values from secrets in all instances based
on the pattern from keystone-init's _keystone_env.tpl (see #147).
Variable are also changed to match keystone's internal parameter names,
and both v2.0 and v3 variable sets can now be passed in to all
components (though the API is still v2.0 only).

Note that this is a **breaking change** to any deployments that
override the default Keystone credentials!