### PR TITLE
Update keystone-init chart

### DIFF
--- a/keystone-init/Chart.yaml
+++ b/keystone-init/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Chart to initialize users in Keystone
 name: keystone-init
-version: 0.1.3
+version: 0.1.4

--- a/keystone-init/templates/_keystone_env.tpl
+++ b/keystone-init/templates/_keystone_env.tpl
@@ -48,6 +48,17 @@ default key names.
 {{- else }}
   value: "{{ .url }}"
 {{- end }}
+{{- if .admin_url }}
+- name: OS_ADMIN_URL
+{{- if eq (kindOf .admin_url) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .admin_url.secret_name }}"
+      key: "{{ .admin_url.secret_key | default "OS_ADMIN_URL" }}"
+{{- else }}
+  value: "{{ .admin_url }}"
+{{- end }}
+{{- end }}
 {{- if .api_version }}
 - name: OS_IDENTITY_API_VERSION
   value: "{{ .api_version }}"

--- a/keystone-init/values.yaml
+++ b/keystone-init/values.yaml
@@ -6,7 +6,7 @@ keystone_init:
 
   image:
     repository: monasca/keystone-init
-    tag: 1.0.2
+    tag: 1.0.3
     pullPolicy: IfNotPresent
 
   # job completion deadline in seconds


### PR DESCRIPTION
new rev of the keystone-init image now includes OS_AUTH_URL for
services that explicitly need it. Auth URL can also be overridden in
keystone-init's config.