### PR TITLE
Add new mysql-users-init chart

### DIFF
--- a/mysql-users-init/.helmignore
+++ b/mysql-users-init/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/mysql-users-init/Chart.yaml
+++ b/mysql-users-init/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Chart to initialize users and databases in MySQL
+name: mysql-users-init
+version: 0.1.0

--- a/mysql-users-init/templates/_helpers.tpl
+++ b/mysql-users-init/templates/_helpers.tpl
@@ -1,0 +1,46 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified cleanup name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cleanup.fullname" -}}
+{{- printf "%s-%s" .Release.Name "cleanup" | trunc 63 -}}
+{{- end -}}
+
+{{- /*
+Read a single optional secret or string from values into an `env` `value:` or
+`valueFrom:`, depending on the user-defined content of the value.
+
+Example:
+  - name: OS_AUTH_URL
+{{ include "mysql_users_secret_env" .Values.auth.url | indent 4 }}
+
+Make sure to change the name of this template when copying to keep it unique,
+e.g. chart_name_secret_env.
+*/}}
+{{- define "mysql_users_init_secret_env" -}}
+{{- if eq (kindOf .) "map" -}}
+valueFrom:
+  secretKeyRef:
+    name: "{{ .secret_name }}"
+    key: "{{ .secret_key }}"
+{{- else -}}
+value: "{{ . }}"
+{{- end -}}
+{{- end -}}

--- a/mysql-users-init/templates/cleanup-pre-upgrade-hook.yaml
+++ b/mysql-users-init/templates/cleanup-pre-upgrade-hook.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # while not recommended, we add a random sequence to the end of the job name
+  # this job will attempt to delete itself when finished, but should it fail for
+  # some reason we don't want future upgrades to fail because of a name conflict
+  # (plus the future runs of this job will delete any previous iterations that
+  # failed to clean themselves up)
+  name: "{{ template "cleanup.fullname" . }}-job-{{ randAlphaNum 5 | lower }}"
+  labels:
+    app: {{ template "fullname" . }}
+    component: "{{ .Values.cleanup.name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        component: "{{ .Values.cleanup.name }}"
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: {{ template "name" . }}-{{ .Values.cleanup.name }}-job
+          image: "{{ .Values.cleanup.image.repository }}:{{ .Values.cleanup.image.tag }}"
+          imagePullPolicy: {{ .Values.cleanup.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.cleanup.resources | indent 12 }}
+          env:
+            - name: "WAIT_RETRIES"
+              value: "{{ .Values.cleanup.wait.retries }}"
+            - name: "WAIT_DELAY"
+              value: "{{ .Values.cleanup.wait.delay }}"
+            - name: "WAIT_TIMEOUT"
+              value: "{{ .Values.cleanup.wait.timeout }}"

--- a/mysql-users-init/templates/mysql-users-init-job.yaml
+++ b/mysql-users-init/templates/mysql-users-init-job.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "fullname" . }}-job
+  labels:
+    app: {{ template "fullname" . }}
+    component: "{{ .Values.mysql_users_init.name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  activeDeadlineSeconds: {{ .Values.mysql_users_init.deadline }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        component: "{{ .Values.mysql_users_init.name }}"
+    spec:
+      restartPolicy: OnFailure
+      volumes:
+        - name: preload-config
+          configMap:
+            name: "{{ template "fullname" . }}-preload"
+            items:
+              - key: preload.yml
+                path: preload.yml
+      containers:
+        - name: {{ template "fullname" . }}-job
+          image: "{{ .Values.mysql_users_init.image.repository }}:{{ .Values.mysql_users_init.image.tag }}"
+          imagePullPolicy: {{ .Values.mysql_users_init.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.mysql_users_init.resources | indent 12 }}
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.mysql_users_init.log_level }}
+            - name: MYSQL_INIT_HOST
+{{ include "mysql_users_init_secret_env" .Values.mysql_users_init.mysql.host | indent 14 }}
+            - name: MYSQL_INIT_PORT
+{{ include "mysql_users_init_secret_env" .Values.mysql_users_init.mysql.port | indent 14 }}
+            - name: MYSQL_INIT_USERNAME
+{{ include "mysql_users_init_secret_env" .Values.mysql_users_init.mysql.username | indent 14 }}
+            - name: MYSQL_INIT_PASSWORD
+{{ include "mysql_users_init_secret_env" .Values.mysql_users_init.mysql.password | indent 14 }}
+          volumeMounts:
+            - name: preload-config
+              mountPath: /preload.yml
+              subPath: preload.yml

--- a/mysql-users-init/templates/mysql-users-preload-configmap.yaml
+++ b/mysql-users-init/templates/mysql-users-preload-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ template "fullname" . }}-preload"
+  labels:
+    app: "{{ template "fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  preload.yml: |
+{{ toYaml .Values.mysql_users_init.preload | indent 4 }}

--- a/mysql-users-init/values.yaml
+++ b/mysql-users-init/values.yaml
@@ -1,0 +1,66 @@
+# Default values for mysql-users-init.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+mysql_users_init:
+  name: job
+
+  image:
+    repository: monasca/mysql-users-init
+    tag: 1.0.0
+    pullPolicy: IfNotPresent
+
+  # job completion deadline in seconds
+  deadline: 300
+
+  # general options for the init job
+  log_level: INFO # python logging level
+
+  # mysql connection details for this component
+  # note that these options allow the init container to connect to mysql and
+  # the referenced account must already exist
+  # each parameter may either be specified directly as a string OR reference a
+  # secret
+  # example:
+  #   # plaintext (will be stored in Helm's ConfigMap)
+  #   password: 'some-plaintext-password'
+  #
+  #   # secret ref
+  #   password:
+  #     secret_name: some-secret-name
+  #     secret_key: some-key
+  mysql:
+    host: mysql
+    port: '3306'
+    username: root
+    password: password
+
+  preload:
+    users: []
+    databases: []
+
+  # container resource limits and requests
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+cleanup:
+  name: cleanup
+  image:
+    repository: monasca/job-cleanup
+    tag: 1.1.2
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 200m
+    limits:
+      memory: 128Mi
+      cpu: 250m
+  wait:
+    retries: "24"
+    delay: "5.0"
+    timeout: "10"


### PR DESCRIPTION
This adds a new chart for creating users and databases in MySQL and
creating Kubernetes secrets from the generated credentials.

Eventually this chart will complement the existing mysql
initialization logic.