### PR TITLE
Use release way of specifying storage class

### DIFF
--- a/kafka/Chart.yaml
+++ b/kafka/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kafka
 name: kafka
-version: 0.2.3
+version: 0.3.1

--- a/kafka/templates/pvc.yaml
+++ b/kafka/templates/pvc.yaml
@@ -8,16 +8,11 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
   name: {{ template "fullname" . }}
-  annotations:
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
-  {{- else }}
-    volume.alpha.kubernetes.io/storage-class: default
-  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
   resources:
+    storageClassName: {{ .Values.persistence.storageClass | quote }}
     requests:
       storage: {{ .Values.persistence.size | quote }}
 {{- end }}

--- a/monasca/Chart.yaml
+++ b/monasca/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Monasca running in Kubernetes
 name: monasca
-version: 0.3.4
+version: 0.4.1
 sources:
 - https://wiki.openstack.org/wiki/Monasca
 maintainers:

--- a/monasca/requirements.yaml
+++ b/monasca/requirements.yaml
@@ -8,7 +8,7 @@ dependencies:
     condition: mysql.enabled, global.mysql.enabled
     repository: 'https://kubernetes-charts.storage.googleapis.com/'
   - name: kafka
-    version: 0.2.3
+    version: 0.3.1
     condition: kafka.enabled, global.kafka.enabled
     repository: 'http://monasca.io/monasca-helm/'
   - name: storm
@@ -16,6 +16,6 @@ dependencies:
     condition: storm.enabled, global.storm.enabled
     repository: 'http://monasca.io/monasca-helm/'
   - name: zookeeper
-    version: 0.2.2
+    version: 0.3.1
     condition: zookeeper.enabled, global.zookeeper.enabled
     repository: 'http://monasca.io/monasca-helm/'

--- a/zookeeper/Chart.yaml
+++ b/zookeeper/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Zookeeper
 name: zookeeper
-version: 0.2.2
+version: 0.3.1

--- a/zookeeper/templates/zookeeper-pvc.yaml
+++ b/zookeeper/templates/zookeeper-pvc.yaml
@@ -8,16 +8,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
-  {{- else }}
-    volume.alpha.kubernetes.io/storage-class: default
-  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
   resources:
+    storageClassName: {{ .Values.persistence.storageClass | quote }}
     requests:
       storage: {{ .Values.persistence.size | quote }}
 {{- end }}


### PR DESCRIPTION
The previous zookeeper and kafka charts a combination of alpha
and beta annotations for setting the storage class. The release
way of doing that is setting the spec property storageClassName.

This breaks helm upgrade if persistent volumes are used so the
minor version is updated on those two charts and monasca which is
changed to use the new charts.