### PR TITLE
Fix storageClassName for zookeeper and kafka

### DIFF
--- a/kafka/Chart.yaml
+++ b/kafka/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kafka
 name: kafka
-version: 0.3.1
+version: 0.3.2

--- a/kafka/templates/pvc.yaml
+++ b/kafka/templates/pvc.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
   resources:
-    storageClassName: {{ .Values.persistence.storageClass | quote }}
     requests:
       storage: {{ .Values.persistence.size | quote }}
 {{- end }}

--- a/zookeeper/Chart.yaml
+++ b/zookeeper/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Zookeeper
 name: zookeeper
-version: 0.3.1
+version: 0.3.2

--- a/zookeeper/templates/zookeeper-pvc.yaml
+++ b/zookeeper/templates/zookeeper-pvc.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
   resources:
-    storageClassName: {{ .Values.persistence.storageClass | quote }}
     requests:
       storage: {{ .Values.persistence.size | quote }}
 {{- end }}


### PR DESCRIPTION
Accidentally put it under resources: instead of at the same
level. Have to bump versions as well.