### PR TITLE
Give kafka an anti-affinity prefernce against influxdb

### DIFF
--- a/kafka/templates/deployment.yaml
+++ b/kafka/templates/deployment.yaml
@@ -69,3 +69,15 @@ spec:
           configMap:
             name: {{ template "fullname" . }}-exporter
         {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - monasca-influxdb
+                topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
This gives the k8s scheduler a hint that kafka and influx should
be run on separate nodes when possible.