### PR TITLE
Fix the monasca api variable in Client container

### DIFF
--- a/monasca/Chart.yaml
+++ b/monasca/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Monasca running in Kubernetes
 name: monasca
-version: 0.4.5
+version: 0.4.7
 sources:
 - https://wiki.openstack.org/wiki/Monasca
 maintainers:

--- a/monasca/templates/client-deployment.yaml
+++ b/monasca/templates/client-deployment.yaml
@@ -43,6 +43,6 @@ spec:
               value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
             {{- end }}
 {{ include "monasca_keystone_env" .Values.client.keystone | indent 12 }}
-            - name: MONASCA_URL
+            - name: MONASCA_API_URL
               value: "http://{{ template "api.fullname" . }}:{{ .Values.api.service.port }}/v2.0"
 {{- end }}


### PR DESCRIPTION
fixes bug:

/ # monasca alarm-count
publicURL endpoint for monitoring service not found