### PR TITLE
Revert "auto-update: monasca/storm 1.0.3.2 -> 1.1.1-1.0.8"

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -405,7 +405,7 @@ storm:
   enabled: false
   image:
     repository: monasca/storm
-    tag: 1.1.1-1.0.8
+    tag: 1.1.1-1.0.0
     pullPolicy: IfNotPresent
   persistence:
     storageClass: default


### PR DESCRIPTION
Reverts monasca/monasca-helm#238

Temporarily reverting until thresh is based on this storm image as well.