### PR TITLE
Add option for kafka stay alive on failure

### DIFF
--- a/kafka/Chart.yaml
+++ b/kafka/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kafka
 name: kafka
-version: 0.3.9
+version: 0.3.10

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -23,3 +23,4 @@ Parameter | Description | Default
 `exporter.port` | Kafka exporter port to expose Promethues metrics on | `7204`
 `stack_size` | JVM stack size | `1024k`
 `memory_ratio` | Ratio of memory to reserve for the JVM out of cgroup limit | `.85`
+`stay_alive_on_failure` | If `true`, container stays alive for 2 hours after kafka exits | `false`

--- a/kafka/templates/deployment.yaml
+++ b/kafka/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
               value: {{ .Values.stack_size | quote }}
             - name: ZOOKEEPER_CONNECTION_STRING
               value: {{ .Release.Name }}-zookeeper:2181
+            - name: STAY_ALIVE_ON_FAILURE
+              value: {{ .Values.stay_alive_on_failure | quote }}
         {{- if .Values.exporter.enabled }}
         - name: {{ .Chart.Name }}-exporter
           image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"

--- a/kafka/values.yaml
+++ b/kafka/values.yaml
@@ -7,7 +7,7 @@ exporter:
   port: 7204
 image:
   repository: monasca/kafka
-  tag: 0.9.0.1-2.11-1.1.5
+  tag: 0.9.0.1-2.11-1.1.6
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
@@ -26,6 +26,7 @@ persistence:
   size: 10Gi
 memory_ratio: .85
 stack_size: 1024k
+stay_alive_on_failure: false
 init:
   enabled: true
   image:


### PR DESCRIPTION
Feature was added to the container, now add it to the chart.
Default is false