### PR TITLE
Use release name for storage-class

### DIFF
--- a/storm/templates/nimbus-pvc.yaml
+++ b/storm/templates/nimbus-pvc.yaml
@@ -10,15 +10,10 @@ metadata:
     component: "{{ .Values.name }}-nimbus"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
-  {{- else }}
-    volume.alpha.kubernetes.io/storage-class: default
-  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}


### PR DESCRIPTION
Don't use volume.beta.kubernetes.io/storage-class as PVCs are
now a released feature