### PR TITLE
Fix grafana-init-job's restart policy

### DIFF
--- a/monasca/templates/grafana-init-job.yaml
+++ b/monasca/templates/grafana-init-job.yaml
@@ -16,7 +16,7 @@ spec:
         app: {{ template "fullname" . }}
         component: "{{ .Values.grafana.name }}-init-job"
     spec:
-      restartPolicy: Never
+      restartPolicy: OnFailure
       containers:
         - name: {{ template "name" . }}-{{ .Values.grafana.name }}-init-job
           image: "{{ .Values.grafana_init.image.repository }}:{{ .Values.grafana_init.image.tag }}"


### PR DESCRIPTION
It was Never when it should have been OnFailure.