### PR TITLE
Clean up some weird pod and container names

### DIFF
--- a/monasca/templates/agent-daemonset.yaml
+++ b/monasca/templates/agent-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.agent.termination_grace_period }}
       containers:
-        - name: {{ template "name" . }}-{{ .Values.agent.name }}-collector-daemonset
+        - name: collector
           image: "{{ .Values.agent.collector.image.repository }}:{{ .Values.agent.collector.image.tag }}"
           imagePullPolicy: {{ .Values.agent.collector.image.pullPolicy }}
           resources:
@@ -95,7 +95,7 @@ spec:
             - name: KUBERNETES_MINIMUM_WHITELIST
               value: "true"
             {{- end }}
-        - name: {{ template "name" . }}-{{ .Values.agent.name }}-forwarder-daemonset
+        - name: forwarder
           image: "{{ .Values.agent.forwarder.image.repository }}:{{ .Values.agent.forwarder.image.tag }}"
           imagePullPolicy: {{ .Values.agent.forwarder.image.pullPolicy }}
           resources:

--- a/monasca/templates/agent-deployment.yaml
+++ b/monasca/templates/agent-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: {{ .Values.agent.termination_grace_period }}
       containers:
-        - name: {{ template "name" . }}-{{ .Values.agent.name }}-collector-deployment
+        - name: collector
           image: "{{ .Values.agent.collector.image.repository }}:{{ .Values.agent.collector.image.tag }}"
           imagePullPolicy: {{ .Values.agent.collector.image.pullPolicy }}
           resources:
@@ -89,7 +89,7 @@ spec:
             - name: agent-config
               mountPath: /plugins.d
           {{- end}}
-        - name: {{ template "name" . }}-{{ .Values.agent.name }}-forwarder-deployment
+        - name: forwarder
           image: "{{ .Values.agent.forwarder.image.repository }}:{{ .Values.agent.forwarder.image.tag }}"
           imagePullPolicy: {{ .Values.agent.forwarder.image.pullPolicy }}
           resources:

--- a/monasca/templates/aggregator-deployment.yaml
+++ b/monasca/templates/aggregator-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         prometheus.io/port: "8080"
     spec:
       containers:
-      - name: {{ template "name" . }}-{{ .Values.aggregator.name }}
+      - name: aggregator
         image: "{{ .Values.aggregator.image.repository }}:{{ .Values.aggregator.image.tag }}"
         imagePullPolicy: {{ .Values.aggregator.image.pullPolicy }}
         resources:

--- a/monasca/templates/alarm-definition-controller-deployment.yaml
+++ b/monasca/templates/alarm-definition-controller-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         component: "{{ .Values.alarm_definition_controller.name }}"
     spec:
       containers:
-        - name: {{ template "name" . }}-{{ .Values.alarm_definition_controller.name }}
+        - name: adc
           image: "{{ .Values.alarm_definition_controller.image.repository }}:{{ .Values.alarm_definition_controller.image.tag }}"
           imagePullPolicy: {{ .Values.alarm_definition_controller.image.pullPolicy }}
           resources:

--- a/monasca/templates/alarms-init-job.yaml
+++ b/monasca/templates/alarms-init-job.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       restartPolicy: OnFailure
       containers:
-        - name: {{ template "name" . }}-{{ .Values.alarms.name }}-init-job
+        - name: alarms-init-job
           image: "{{ .Values.alarms.image.repository }}:{{ .Values.alarms.image.tag }}"
           imagePullPolicy: {{ .Values.alarms.image.pullPolicy }}
           resources:

--- a/monasca/templates/api-deployment.yaml
+++ b/monasca/templates/api-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       {{- end }}
     spec:
       containers:
-      - name: {{ template "name" . }}-{{ .Values.api.name }}
+      - name: api
         image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
         imagePullPolicy: {{ .Values.api.image.pullPolicy }}
         resources:
@@ -152,7 +152,7 @@ spec:
             - name: GUNICORN_WORKERS
               value: {{ .Values.api.gunicorn_workers | quote }}
       {{- if .Values.api.side_container.enabled }}
-      - name: {{ template "name" . }}-{{ .Values.api.name }}-side-container
+      - name: sidecar
         image: "{{ .Values.api.side_container.image.repository }}:{{ .Values.api.side_container.image.tag }}"
         imagePullPolicy: {{ .Values.api.side_container.image.pullPolicy }}
         resources:

--- a/monasca/templates/client-deployment.yaml
+++ b/monasca/templates/client-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app: {{ template "fullname" . }}
     spec:
       containers:
-        - name: {{ template "name" . }}-{{ .Values.client.name }}-deployment
+        - name: client
           image: "{{ .Values.client.image.repository }}:{{ .Values.client.image.tag }}"
           imagePullPolicy: {{ .Values.client.image.pullPolicy }}
           command:

--- a/monasca/templates/forwarder-deployment.yaml
+++ b/monasca/templates/forwarder-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         checksum/metric_config: {{ toYaml .Values.forwarder.metric_configuration | sha256sum }}
     spec:
       containers:
-      - name: {{ template "name" . }}-{{ .Values.forwarder.name }}
+      - name: forwarder
         image: "{{ .Values.forwarder.image.repository }}:{{ .Values.forwarder.image.tag }}"
         imagePullPolicy: {{ .Values.forwarder.image.pullPolicy }}
         resources:

--- a/monasca/templates/grafana-deployment.yaml
+++ b/monasca/templates/grafana-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         component: "{{ .Values.grafana.name }}"
     spec:
       containers:
-        - name: {{ template "name" . }}-{{ .Values.grafana.name }}
+        - name: grafana
           image: "{{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}"
           imagePullPolicy: {{ .Values.grafana.image.pullPolicy }}
           resources:

--- a/monasca/templates/grafana-init-job.yaml
+++ b/monasca/templates/grafana-init-job.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       restartPolicy: OnFailure
       containers:
-        - name: {{ template "name" . }}-{{ .Values.grafana.name }}-init-job
+        - name: grafana-init-job
           image: "{{ .Values.grafana_init.image.repository }}:{{ .Values.grafana_init.image.tag }}"
           imagePullPolicy: {{ .Values.grafana_init.image.pullPolicy }}
           resources:

--- a/monasca/templates/influx-init-job.yaml
+++ b/monasca/templates/influx-init-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: influx-init-job
+  name: {{ .Release.Name }}-influx-init-job
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/monasca/templates/keystone-deployment.yaml
+++ b/monasca/templates/keystone-deployment.yaml
@@ -25,7 +25,7 @@ spec:
               - key: preload.yml
                 path: preload.yml
       containers:
-        - name: {{ template "name" . }}-{{ .Values.keystone.name }}
+        - name: keystone
           image: "{{ .Values.keystone.image.repository }}:{{ .Values.keystone.image.tag }}"
           imagePullPolicy: {{ .Values.keystone.image.pullPolicy }}
           resources:

--- a/monasca/templates/memcached-deployment.yaml
+++ b/monasca/templates/memcached-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         component: "{{ .Values.memcached.name }}"
     spec:
       containers:
-      - name: {{ template "name" . }}-{{ .Values.memcached.name }}
+      - name: memcached
         image: "{{ .Values.memcached.image.repository }}:{{ .Values.memcached.image.tag }}"
         imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
         resources:

--- a/monasca/templates/mysql-init-job.yaml
+++ b/monasca/templates/mysql-init-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: mysql-init-job
+  name: {{ .Release.Name }}-mysql-init-job
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/monasca/templates/notification-deployment.yaml
+++ b/monasca/templates/notification-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         component: "{{ .Values.notification.name }}"
     spec:
       containers:
-        - name: {{ template "name" . }}-{{ .Values.notification.name }}
+        - name: notification
           image: "{{ .Values.notification.image.repository }}:{{ .Values.notification.image.tag }}"
           imagePullPolicy: {{ .Values.notification.image.pullPolicy }}
           resources:

--- a/monasca/templates/persister-deployment.yaml
+++ b/monasca/templates/persister-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         component: "{{ .Values.persister.name }}"
     spec:
       containers:
-      - name: {{ template "name" . }}-{{ .Values.persister.name }}
+      - name: persister
         image: "{{ .Values.persister.image.repository }}:{{ .Values.persister.image.tag }}"
         imagePullPolicy: {{ .Values.persister.image.pullPolicy }}
         resources:

--- a/monasca/templates/smoke-test-pod.yaml
+++ b/monasca/templates/smoke-test-pod.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   restartPolicy: Never
   containers:
-    - name: {{ template "name" . }}-{{ .Values.smoke_tests.name }}-test-pod
+    - name: smoke-tests
       image: "{{ .Values.smoke_tests.image.repository }}:{{ .Values.smoke_tests.image.tag }}"
       imagePullPolicy: {{ .Values.smoke_tests.image.pullPolicy }}
       resources:

--- a/monasca/templates/tempest-tests-pod.yaml
+++ b/monasca/templates/tempest-tests-pod.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   restartPolicy: Never
   containers:
-    - name: {{ template "name" . }}-{{ .Values.tempest_tests.name }}-test-pod
+    - name: tempest-tests
       image: "{{ .Values.tempest_tests.image.repository }}:{{ .Values.tempest_tests.image.tag }}"
       imagePullPolicy: {{ .Values.tempest_tests.image.pullPolicy }}
       env:

--- a/monasca/templates/thresh-deployment.yaml
+++ b/monasca/templates/thresh-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-        - name: {{ template "name" . }}-{{ .Values.thresh.name }}-deployment
+        - name: thresh
           image: "{{ .Values.thresh.image.repository }}:{{ .Values.thresh.image.tag }}"
           imagePullPolicy: {{ .Values.thresh.image.pullPolicy }}
           resources:


### PR DESCRIPTION
- prefix influx-init and mysql-init with `{{ .Release.Name }}`
 - don't bother templating container names, just use a fixed name
   (k8s' internal docker container names are still unique, this just
   reduces the amount of typing needed to get logs or exec into a
   multi-container pod)