### PR TITLE
Allow more agent configuration

### DIFF
--- a/monasca-agent/templates/daemonset.yaml
+++ b/monasca-agent/templates/daemonset.yaml
@@ -72,6 +72,14 @@ spec:
             - name: DIMENSIONS
               value: {{ .Values.dimensions | quote}}
             {{- end}}
+            - name: CHECK_FREQ
+              value: {{ .Values.collector.check_freq | quote }}
+            - name: NUM_COLLECTOR_THREADS
+              value: {{ .Values.collector.num_collector_threads | quote }}
+            - name: POOL_FULL_MAX_TRIES
+              value: {{ .Values.collector.pool_full_max_retries | quote }}
+            - name: SUB_COLLECTION_WARN
+              value: {{ .Values.collector.sub_collection_warn | quote }}
         - name: {{ template "name" . }}-forwarder-daemonset
           image: "{{ .Values.forwarder.image.repository }}:{{ .Values.forwarder.image.tag }}"
           imagePullPolicy: {{ .Values.forwarder.image.pullPolicy }}
@@ -104,5 +112,11 @@ spec:
               value: {{ .Values.log_level | quote }}
             - name: INSECURE
               value: {{ .Values.insecure | quote }}
+            - name: MAX_BATCH_SIZE
+              value: {{ .Values.forwarder.max_batch_size | quote }}
+            - name: MAX_MEASUREMENT_BUFFER_SIZE
+              value: {{ .Values.forwarder.max_measurement_buffer_size | quote }}
+            - name: BACKLOG_SEND_RATE
+              value: {{ .Values.forwarder.backlog_send_rate | quote }}
             - name: HOSTNAME_FROM_KUBERNETES
               value: "true"

--- a/monasca-agent/templates/deployment.yaml
+++ b/monasca-agent/templates/deployment.yaml
@@ -71,6 +71,14 @@ spec:
             - name: REPORT_PERSISTENT_STORAGE
               value: {{ .Values.kubernetes_api.storage.report | quote }}
             {{- if .Values.dimensions }}
+            - name: CHECK_FREQ
+              value: {{ .Values.collector.check_freq | quote }}
+            - name: NUM_COLLECTOR_THREADS
+              value: {{ .Values.collector.num_collector_threads | quote }}
+            - name: POOL_FULL_MAX_TRIES
+              value: {{ .Values.collector.pool_full_max_retries | quote }}
+            - name: SUB_COLLECTION_WARN
+              value: {{ .Values.collector.sub_collection_warn | quote }}
             - name: DIMENSIONS
               value: {{ .Values.dimensions | quote}}
             {{- end}}

--- a/monasca-agent/templates/deployment.yaml
+++ b/monasca-agent/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
             - name: REPORT_PERSISTENT_STORAGE
               value: {{ .Values.kubernetes_api.storage.report | quote }}
             {{- if .Values.dimensions }}
+            - name: DIMENSIONS
+              value: {{ .Values.dimensions | quote}}
+            {{- end}}
             - name: CHECK_FREQ
               value: {{ .Values.collector.check_freq | quote }}
             - name: NUM_COLLECTOR_THREADS
@@ -79,9 +82,6 @@ spec:
               value: {{ .Values.collector.pool_full_max_retries | quote }}
             - name: SUB_COLLECTION_WARN
               value: {{ .Values.collector.sub_collection_warn | quote }}
-            - name: DIMENSIONS
-              value: {{ .Values.dimensions | quote}}
-            {{- end}}
           {{- if .Values.plugins.enabled }}
           volumeMounts:
             - name: agent-config
@@ -120,11 +120,11 @@ spec:
             - name: INSECURE
               value: {{ .Values.insecure | quote }}
             - name: MAX_BATCH_SIZE
-              value: {{ .Values.agent.forwarder.max_batch_size | quote }}
+              value: {{ .Values.forwarder.max_batch_size | quote }}
             - name: MAX_MEASUREMENT_BUFFER_SIZE
-              value: {{ .Values.agent.forwarder.max_measurement_buffer_size | quote }}
+              value: {{ .Values.forwarder.max_measurement_buffer_size | quote }}
             - name: BACKLOG_SEND_RATE
-              value: {{ .Values.agent.forwarder.backlog_send_rate | quote }}
+              value: {{ .Values.forwarder.backlog_send_rate | quote }}
             - name: HOSTNAME_FROM_KUBERNETES
               value: "true"
       {{- if .Values.plugins.enabled }}

--- a/monasca-agent/templates/deployment.yaml
+++ b/monasca-agent/templates/deployment.yaml
@@ -111,6 +111,12 @@ spec:
               value: {{ .Values.log_level | quote }}
             - name: INSECURE
               value: {{ .Values.insecure | quote }}
+            - name: MAX_BATCH_SIZE
+              value: {{ .Values.agent.forwarder.max_batch_size | quote }}
+            - name: MAX_MEASUREMENT_BUFFER_SIZE
+              value: {{ .Values.agent.forwarder.max_measurement_buffer_size | quote }}
+            - name: BACKLOG_SEND_RATE
+              value: {{ .Values.agent.forwarder.backlog_send_rate | quote }}
             - name: HOSTNAME_FROM_KUBERNETES
               value: "true"
       {{- if .Values.plugins.enabled }}

--- a/monasca-agent/values.yaml
+++ b/monasca-agent/values.yaml
@@ -4,11 +4,18 @@ collector:
     repository: monasca/agent-collector
     tag: master-20180105-183106
     pullPolicy: IfNotPresent
+  check_freq: 30
+  num_collector_threads: 1
+  pool_full_max_retries: 4
+  sub_collection_warn: 6
 forwarder:
   image:
     repository: monasca/agent-forwarder
     tag: master-20180105-183106
     pullPolicy: IfNotPresent
+  max_batch_size: 0
+  max_measurement_buffer_size: 1000
+  backlog_send_rate: 5
 insecure: False
 log_level: WARN
 keystone:

--- a/monasca-agent/values.yaml
+++ b/monasca-agent/values.yaml
@@ -14,7 +14,7 @@ forwarder:
     tag: master-20180105-183106
     pullPolicy: IfNotPresent
   max_batch_size: 0
-  max_measurement_buffer_size: 1000
+  max_measurement_buffer_size: -1
   backlog_send_rate: 5
 insecure: False
 log_level: WARN

--- a/monasca/README.md
+++ b/monasca/README.md
@@ -183,7 +183,7 @@ Parameter | Description | Default
 `agent.forwarder.image.tag` | Agent Forwarder container image tag | `master-20170615-204444`
 `agent.forwarder.image.pullPolicy` | Agent Forwarder container image pull policy | `IfNotPresent`
 `agent.forwarder.max_batch_size` | Maximum batch size of measurements to write to monasca-api, 0 is no limit | `0`
-`agent.forwarder.max_measurement_buffer_size` | Maximum number of measurements to buffer when unable to communicate with the monasca-api (-1 means no limit)| `1000`
+`agent.forwarder.max_measurement_buffer_size` | Maximum number of measurements to buffer when unable to communicate with the monasca-api (-1 means no limit)| `-1`
 `agent.forwarder.backlog_send_rate` | Maximum number of messages to send at one time when communication with the monasca-api is restored | `5`
 `agent.dimensions` | Default dimensions to attach to every metric being sent | ``
 `agent.plugins.enabled` | Enable passing in agent plugins | `False`

--- a/monasca/README.md
+++ b/monasca/README.md
@@ -175,9 +175,16 @@ Parameter | Description | Default
 `agent.collector.image.repository` | Agent Collector container image repository | `monasca/agent-collector`
 `agent.collector.image.tag` | Agent Collector container image tag | `master-20170707-154334`
 `agent.collector.image.pullPolicy` | Agent Collector container image pull policy | `IfNotPresent`
+`agent.collector.check_freq` | How often to run metric collection in seconds | `30`
+`agent.collector.num_collector_threads` | Number of threads to use in collector for running checks | `1`
+`agent.collector.pool_full_max_retries` |  Maximum number of collection cycles where all of the threads in the pool are still running plugins before the collector will exit | `4`
+`agent.collector.sub_collection_warn` | Number of seconds a plugin collection time exceeds that causes a warning to be logged for that plugin | `6`
 `agent.forwarder.image.repository` | Agent Forwarder container image repository | `monasca/agent-forwarder`
 `agent.forwarder.image.tag` | Agent Forwarder container image tag | `master-20170615-204444`
 `agent.forwarder.image.pullPolicy` | Agent Forwarder container image pull policy | `IfNotPresent`
+`agent.forwarder.max_batch_size` | Maximum batch size of measurements to write to monasca-api, 0 is no limit | `0`
+`agent.forwarder.max_measurement_buffer_size` | Maximum number of measurements to buffer when unable to communicate with the monasca-api (-1 means no limit)| `1000`
+`agent.forwarder.backlog_send_rate` | Maximum number of messages to send at one time when communication with the monasca-api is restored | `5`
 `agent.dimensions` | Default dimensions to attach to every metric being sent | ``
 `agent.plugins.enabled` | Enable passing in agent plugins | `False`
 `agent.plugins.config_files` | List of plugin yamls to be used with the agent | ``

--- a/monasca/templates/agent-daemonset.yaml
+++ b/monasca/templates/agent-daemonset.yaml
@@ -87,6 +87,14 @@ spec:
             - name: DIMENSIONS
               value: {{ .Values.agent.dimensions | quote}}
             {{- end}}
+            - name: CHECK_FREQ
+              value: {{ .Values.agent.collector.check_freq | quote }}
+            - name: NUM_COLLECTOR_THREADS
+              value: {{ .Values.agent.collector.num_collector_threads | quote }}
+            - name: POOL_FULL_MAX_TRIES
+              value: {{ .Values.agent.collector.pool_full_max_retries | quote }}
+            - name: SUB_COLLECTION_WARN
+              value: {{ .Values.agent.collector.sub_collection_warn | quote }}
             {{- if .Values.agent.cadvisor.enable_minimum_whitelist }}
             - name: CADVISOR_MINIMUM_WHITELIST
               value: "true"
@@ -133,6 +141,12 @@ spec:
               value: {{ .Values.agent.log_level | quote }}
             - name: INSECURE
               value: {{ .Values.agent.insecure | quote }}
+            - name: MAX_BATCH_SIZE
+              value: {{ .Values.agent.forwarder.max_batch_size | quote }}
+            - name: MAX_MEASUREMENT_BUFFER_SIZE
+              value: {{ .Values.agent.forwarder.max_measurement_buffer_size | quote }}
+            - name: BACKLOG_SEND_RATE
+              value: {{ .Values.agent.forwarder.backlog_send_rate | quote }}
             - name: HOSTNAME_FROM_KUBERNETES
               value: "true"
 {{- end}}

--- a/monasca/templates/agent-deployment.yaml
+++ b/monasca/templates/agent-deployment.yaml
@@ -80,6 +80,10 @@ spec:
             {{- end}}
             - name: REPORT_PERSISTENT_STORAGE
               value: {{ .Values.agent.kubernetes_api.storage.report | quote }}
+            {{- if .Values.agent.dimensions }}
+            - name: DIMENSIONS
+              value: {{ .Values.agent.dimensions | quote}}
+            {{- end}}
             - name: CHECK_FREQ
               value: {{ .Values.agent.collector.check_freq | quote }}
             - name: NUM_COLLECTOR_THREADS
@@ -88,10 +92,6 @@ spec:
               value: {{ .Values.agent.collector.pool_full_max_retries | quote }}
             - name: SUB_COLLECTION_WARN
               value: {{ .Values.agent.collector.sub_collection_warn | quote }}
-            {{- if .Values.agent.dimensions }}
-            - name: DIMENSIONS
-              value: {{ .Values.agent.dimensions | quote}}
-            {{- end}}
           {{- if .Values.agent.plugins.enabled }}
           volumeMounts:
             - name: agent-config

--- a/monasca/templates/agent-deployment.yaml
+++ b/monasca/templates/agent-deployment.yaml
@@ -80,6 +80,14 @@ spec:
             {{- end}}
             - name: REPORT_PERSISTENT_STORAGE
               value: {{ .Values.agent.kubernetes_api.storage.report | quote }}
+            - name: CHECK_FREQ
+              value: {{ .Values.agent.collector.check_freq | quote }}
+            - name: NUM_COLLECTOR_THREADS
+              value: {{ .Values.agent.collector.num_collector_threads | quote }}
+            - name: POOL_FULL_MAX_TRIES
+              value: {{ .Values.agent.collector.pool_full_max_retries | quote }}
+            - name: SUB_COLLECTION_WARN
+              value: {{ .Values.agent.collector.sub_collection_warn | quote }}
             {{- if .Values.agent.dimensions }}
             - name: DIMENSIONS
               value: {{ .Values.agent.dimensions | quote}}
@@ -127,6 +135,12 @@ spec:
               value: {{ .Values.agent.log_level | quote }}
             - name: INSECURE
               value: {{ .Values.agent.insecure | quote }}
+            - name: MAX_BATCH_SIZE
+              value: {{ .Values.agent.forwarder.max_batch_size | quote }}
+            - name: MAX_MEASUREMENT_BUFFER_SIZE
+              value: {{ .Values.agent.forwarder.max_measurement_buffer_size | quote }}
+            - name: BACKLOG_SEND_RATE
+              value: {{ .Values.agent.forwarder.backlog_send_rate | quote }}
       {{- if .Values.agent.plugins.enabled }}
       volumes:
         - name: agent-config

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -121,11 +121,18 @@ agent:
       repository: monasca/agent-collector
       tag: master-20180105-183106
       pullPolicy: IfNotPresent
+    check_freq: 30
+    num_collector_threads: 1
+    pool_full_max_retries: 4
+    sub_collection_warn: 6
   forwarder:
     image:
       repository: monasca/agent-forwarder
       tag: master-20180105-183106
       pullPolicy: IfNotPresent
+    max_batch_size: 0
+    max_measurement_buffer_size: 1000
+    backlog_send_rate: 5
   log_level: WARN
   insecure: False
   keystone:

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -131,7 +131,7 @@ agent:
       tag: master-20180105-183106
       pullPolicy: IfNotPresent
     max_batch_size: 0
-    max_measurement_buffer_size: 1000
+    max_measurement_buffer_size: -1
     backlog_send_rate: 5
   log_level: WARN
   insecure: False


### PR DESCRIPTION
The current need is the ability to set max_batch_size. But, I've
added other parameters that may be required. The defaults are the
same as those specified in monasca-docker, so there should be
no change in behavior unless a helm value is overridden