### PR TITLE
auto-update: alarm-definition-controller -> 1.1.0

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -1604,7 +1604,7 @@ alarm_definition_controller:
   resource_enabled: true
   image:
     repository: monasca/alarm-definition-controller
-    tag: 1.0.3
+    tag: 1.1.0
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
Dependency `alarm-definition-controller` from dockerhub repository
monasca-docker was updated to version `1.1.0`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: alarm-definition-controller
Source-Module-Type: docker
Destination-Module: monasca
Destination-Module-Type: helm
