### PR TITLE
auto-update: grafana -> 4.0.0-1.4.1

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -279,7 +279,7 @@ grafana:
   enabled: true
   image:
     repository: monasca/grafana
-    tag: 4.0.0-1.3.4
+    tag: 4.0.0-1.4.1
     pullPolicy: IfNotPresent
   service:
     type: NodePort


### PR DESCRIPTION
Dependency `grafana` from dockerhub repository monasca-docker was
updated to version `4.0.0-1.4.1`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: grafana
Source-Module-Type: docker
Destination-Module: monasca
Destination-Module-Type: helm
