### PR TITLE
auto-update: storm -> 1.1.1-1.0.12

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -419,7 +419,7 @@ storm:
   enabled: false
   image:
     repository: monasca/storm
-    tag: 1.1.1-1.0.11
+    tag: 1.1.1-1.0.12
     pullPolicy: IfNotPresent
   persistence:
     storageClass: default


### PR DESCRIPTION
Dependency `storm` from dockerhub repository monasca-docker was
updated to version `1.1.1-1.0.12`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: storm
Source-Module-Type: docker
Destination-Module: monasca
Destination-Module-Type: helm
