### PR TITLE
auto-update: storm -> 1.1.1-1.0.12

### DIFF
--- a/storm/values.yaml
+++ b/storm/values.yaml
@@ -2,7 +2,7 @@ name: storm
 enabled: true
 image:
   repository: monasca/storm
-  tag: 1.1.1-1.0.11
+  tag: 1.1.1-1.0.12
   pullPolicy: Always
 persistence:
   storageClass: default


### PR DESCRIPTION
Dependency `storm` from dockerhub repository monasca-docker was
updated to version `1.1.1-1.0.12`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: storm
Source-Module-Type: docker
Destination-Module: storm
Destination-Module-Type: helm
