### PR TITLE
auto-update: thresh -> master-20180216-100233

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -447,7 +447,7 @@ storm:
     name: thresh
     image:
       repository: monasca/thresh
-      tag: master-20171205-104226
+      tag: master-20180216-100233
       pullPolicy: IfNotPresent
     mysql:
       port: "3306"
@@ -486,7 +486,7 @@ thresh:
   use_local: true
   image:
     repository: monasca/thresh
-    tag: master-20171205-104226
+    tag: master-20180216-100233
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
Dependency `thresh` from dockerhub repository monasca-docker was
updated to version `master-20180216-100233`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: thresh
Source-Module-Type: docker
Destination-Module: monasca
Destination-Module-Type: helm
