### PR TITLE
auto-update: aggregator -> 0.1.6

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -693,7 +693,7 @@ aggregator:
   name: aggregator
   image:
     repository: monasca/aggregator
-    tag: 0.1.4
+    tag: 0.1.6
     pullPolicy: IfNotPresent
   window_size: 60
   window_lag: 2


### PR DESCRIPTION
Dependency `aggregator` from dockerhub repository monasca-docker was
updated to version `0.1.6`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: aggregator
Source-Module-Type: docker
Destination-Module: monasca
Destination-Module-Type: helm
