### PR TITLE
[mysql-users-init] Add RBAC to mysql-users-init

### DIFF
--- a/mysql-users-init/Chart.yaml
+++ b/mysql-users-init/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Chart to initialize users and databases in MySQL
 name: mysql-users-init
-version: 0.1.3
+version: 0.2.0

--- a/mysql-users-init/templates/cleanup-hook.yaml
+++ b/mysql-users-init/templates/cleanup-hook.yaml
@@ -40,6 +40,8 @@ spec:
               value: "{{ .Values.cleanup.wait.delay }}"
             - name: "WAIT_TIMEOUT"
               value: "{{ .Values.cleanup.wait.timeout }}"
-      {{- if .Values.rbac.create }}
+      {{- if .Values.cleanup.serviceAccount }}
+      serviceAccountName: {{ .Values.cleanup.serviceAccount | quote }}
+      {{- else if .Values.rbac.create }}
       serviceAccountName: "{{ template "cleanup.fullname" . }}"
       {{- end }}

--- a/mysql-users-init/templates/cleanup-hook.yaml
+++ b/mysql-users-init/templates/cleanup-hook.yaml
@@ -40,3 +40,6 @@ spec:
               value: "{{ .Values.cleanup.wait.delay }}"
             - name: "WAIT_TIMEOUT"
               value: "{{ .Values.cleanup.wait.timeout }}"
+      {{- if .Values.rbac.create }}
+      serviceAccountName: "{{ template "cleanup.fullname" . }}"
+      {{- end }}

--- a/mysql-users-init/templates/cleanup-role.yaml
+++ b/mysql-users-init/templates/cleanup-role.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.rbac.create }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+kind: Role
+metadata:
+  name: {{ template "cleanup.fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.cleanup.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete", "patch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "delete"]
+{{- end }}

--- a/mysql-users-init/templates/cleanup-role.yaml
+++ b/mysql-users-init/templates/cleanup-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and (.Values.rbac.create) (not .Values.cleanup.serviceAccount) }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}

--- a/mysql-users-init/templates/cleanup-rolebinding.yaml
+++ b/mysql-users-init/templates/cleanup-rolebinding.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.rbac.create }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+kind: RoleBinding
+metadata:
+  name: {{ template "cleanup.fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.cleanup.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "cleanup.fullname" . }}
+    namespace: "{{ .Release.Namespace }}"
+roleRef:
+  kind: Role
+  name: {{ template "cleanup.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/mysql-users-init/templates/cleanup-rolebinding.yaml
+++ b/mysql-users-init/templates/cleanup-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and (.Values.rbac.create) (not .Values.cleanup.serviceAccount) }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}

--- a/mysql-users-init/templates/cleanup-serviceaccount.yaml
+++ b/mysql-users-init/templates/cleanup-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cleanup.fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.cleanup.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/mysql-users-init/templates/cleanup-serviceaccount.yaml
+++ b/mysql-users-init/templates/cleanup-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and (.Values.rbac.create) (not .Values.cleanup.serviceAccount) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/mysql-users-init/templates/mysql-users-init-job.yaml
+++ b/mysql-users-init/templates/mysql-users-init-job.yaml
@@ -47,6 +47,8 @@ spec:
             - name: preload-config
               mountPath: /preload.yml
               subPath: preload.yml
-      {{- if .Values.rbac.create }}
+      {{- if .Values.mysql_users_init.serviceAccount }}
+      serviceAccountName: {{ .Values.mysql_users_init.serviceAccount | quote }}
+      {{- else if .Values.rbac.create }}
       serviceAccountName: "{{ template "fullname" . }}"
       {{- end }}

--- a/mysql-users-init/templates/mysql-users-init-job.yaml
+++ b/mysql-users-init/templates/mysql-users-init-job.yaml
@@ -47,3 +47,6 @@ spec:
             - name: preload-config
               mountPath: /preload.yml
               subPath: preload.yml
+      {{- if .Values.rbac.create }}
+      serviceAccountName: "{{ template "fullname" . }}"
+      {{- end }}

--- a/mysql-users-init/templates/mysql-users-init-role.yaml
+++ b/mysql-users-init/templates/mysql-users-init-role.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.rbac.create }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+kind: Role
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.mysql_users_init.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "create"]
+{{- end }}

--- a/mysql-users-init/templates/mysql-users-init-role.yaml
+++ b/mysql-users-init/templates/mysql-users-init-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and (.Values.rbac.create) (not .Values.mysql_users_init.serviceAccount) }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}

--- a/mysql-users-init/templates/mysql-users-init-rolebinding.yaml
+++ b/mysql-users-init/templates/mysql-users-init-rolebinding.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.rbac.create }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+kind: RoleBinding
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.mysql_users_init.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fullname" . }}
+    namespace: "{{ .Release.Namespace }}"
+roleRef:
+  kind: Role
+  name: {{ template "fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/mysql-users-init/templates/mysql-users-init-rolebinding.yaml
+++ b/mysql-users-init/templates/mysql-users-init-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and (.Values.rbac.create) (not .Values.mysql_users_init.serviceAccount) }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}

--- a/mysql-users-init/templates/mysql-users-init-serviceaccount.yaml
+++ b/mysql-users-init/templates/mysql-users-init-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and (.Values.rbac.create) (not .Values.mysql_users_init.serviceAccount) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/mysql-users-init/templates/mysql-users-init-serviceaccount.yaml
+++ b/mysql-users-init/templates/mysql-users-init-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.mysql_users_init.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/mysql-users-init/values.yaml
+++ b/mysql-users-init/values.yaml
@@ -4,6 +4,11 @@
 mysql_users_init:
   name: job
 
+  # an optional preexisting serviceAccount to use
+  # to create a service account with the deployment,
+  # deploy with rbac.create=true
+  serviceAccount: ''
+
   image:
     repository: monasca/mysql-users-init
     tag: 1.1.0
@@ -46,6 +51,7 @@ mysql_users_init:
 
 cleanup:
   name: cleanup
+  serviceAccount: ''
   image:
     repository: monasca/job-cleanup
     tag: 1.2.1

--- a/mysql-users-init/values.yaml
+++ b/mysql-users-init/values.yaml
@@ -48,7 +48,7 @@ cleanup:
   name: cleanup
   image:
     repository: monasca/job-cleanup
-    tag: 1.1.2
+    tag: 1.2.1
     pullPolicy: IfNotPresent
   resources:
     requests:
@@ -61,3 +61,6 @@ cleanup:
     retries: "24"
     delay: "5.0"
     timeout: "10"
+
+rbac:
+  create: false


### PR DESCRIPTION
This adds RBAC support to mysql-users-init and its cleanup job.

Signed-off-by: Tim Buckley <timothy.jas.buckley@hpe.com>