### PR TITLE
Add optional serviceAccount parameter for the cleanup hook

### DIFF
--- a/keystone-init/Chart.yaml
+++ b/keystone-init/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Chart to initialize users in Keystone
 name: keystone-init
-version: 0.3.0
+version: 0.3.1

--- a/keystone-init/templates/cleanup-hook.yaml
+++ b/keystone-init/templates/cleanup-hook.yaml
@@ -40,8 +40,8 @@ spec:
               value: "{{ .Values.cleanup.wait.delay }}"
             - name: "WAIT_TIMEOUT"
               value: "{{ .Values.cleanup.wait.timeout }}"
-      {{- if .Values.rbac.hookServiceAccount }}
-      serviceAccountName: {{ .Values.cleanup.hookServiceAccount }}
+      {{- if .Values.cleanup.serviceAccount }}
+      serviceAccountName: {{ .Values.cleanup.serviceAccount | quote }}
       {{- else if .Values.rbac.create }}
       serviceAccountName: "{{ template "cleanup.fullname" . }}"
       {{- end }}

--- a/keystone-init/templates/cleanup-hook.yaml
+++ b/keystone-init/templates/cleanup-hook.yaml
@@ -40,6 +40,8 @@ spec:
               value: "{{ .Values.cleanup.wait.delay }}"
             - name: "WAIT_TIMEOUT"
               value: "{{ .Values.cleanup.wait.timeout }}"
-      {{- if .Values.rbac.create }}
+      {{- if .Values.rbac.hookServiceAccount }}
+      serviceAccountName: {{ .Values.cleanup.hookServiceAccount }}
+      {{- else if .Values.rbac.create }}
       serviceAccountName: "{{ template "cleanup.fullname" . }}"
       {{- end }}

--- a/keystone-init/templates/keystone-init-job.yaml
+++ b/keystone-init/templates/keystone-init-job.yaml
@@ -46,6 +46,8 @@ spec:
             - name: preload-config
               mountPath: /preload.yml
               subPath: preload.yml
-      {{- if .Values.rbac.create }}
+      {{- if .Values.keystone_init.serviceAccount }}
+      serviceAccountName: {{ .Values.keystone_init.serviceAccount | quote }}
+      {{- else if .Values.rbac.create }}
       serviceAccountName: "{{ template "fullname" . }}"
       {{- end }}

--- a/keystone-init/values.yaml
+++ b/keystone-init/values.yaml
@@ -83,6 +83,7 @@ keystone_init:
 
 cleanup:
   name: cleanup
+  serviceAccount: ''
   image:
     repository: monasca/job-cleanup
     tag: 1.2.1

--- a/keystone-init/values.yaml
+++ b/keystone-init/values.yaml
@@ -4,6 +4,11 @@
 keystone_init:
   name: keystone-init
 
+  # an optional preexisting serviceAccount to use
+  # to create a service account with the deployment,
+  # deploy with rbac.create=true
+  serviceAccount: ''
+
   image:
     repository: monasca/keystone-init
     tag: 1.2.2


### PR DESCRIPTION
The cleanup hook makes it impossible to upgrade to a cluster with
RBAC as its own ServiceAccount will not exist before the cleanup job
itself is run. There are two possible solutions to this:

 - Use `helm upgrade --no-hooks` to skip running hooks for the
   initial upgrade. helm will add the necessary service account and
   RBAC rules during the upgrade, though the cleanup job will be
   skipped. Future upgrades will work as expected.
 - Allow users to specify a preexisting serviceAccount for the
   cleanup hook.

This patch adds support for the second option. Users can opt to
upgrade once with `--no-hooks` instead if desired, or create a
service account for hooks in advance to avoid edge cases.