### PR TITLE
[keystone-init] don't create RBAC rules when serviceAccount is set

### DIFF
--- a/keystone-init/Chart.yaml
+++ b/keystone-init/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Chart to initialize users in Keystone
 name: keystone-init
-version: 0.3.1
+version: 0.3.2

--- a/keystone-init/templates/cleanup-role.yaml
+++ b/keystone-init/templates/cleanup-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and (.Values.rbac.create) (not .Values.cleanup.serviceAccount) }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}

--- a/keystone-init/templates/cleanup-rolebinding.yaml
+++ b/keystone-init/templates/cleanup-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and (.Values.rbac.create) (not .Values.cleanup.serviceAccount) }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}

--- a/keystone-init/templates/cleanup-serviceaccount.yaml
+++ b/keystone-init/templates/cleanup-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and (.Values.rbac.create) (not .Values.cleanup.serviceAccount) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/keystone-init/templates/keystone-role.yaml
+++ b/keystone-init/templates/keystone-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and (.Values.rbac.create) (not .Values.keystone_init.serviceAccount) }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}

--- a/keystone-init/templates/keystone-rolebinding.yaml
+++ b/keystone-init/templates/keystone-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and (.Values.rbac.create) (not .Values.keystone_init.serviceAccount) }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}

--- a/keystone-init/templates/keystone-serviceaccount.yaml
+++ b/keystone-init/templates/keystone-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and (.Values.rbac.create) (not .Values.keystone_init.serviceAccount) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
If a `cleanup.serviceAccount` or `keystone_init.serviceAccount`
override is set, don't create any RBAC resources for that component.