### PR TITLE
[keystone-init] [mysql-users-init] Don't use subpath mounts

### DIFF
--- a/keystone-init/Chart.yaml
+++ b/keystone-init/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Chart to initialize users in Keystone
 name: keystone-init
-version: 0.3.2
+version: 0.3.3

--- a/keystone-init/templates/keystone-init-job.yaml
+++ b/keystone-init/templates/keystone-init-job.yaml
@@ -23,9 +23,6 @@ spec:
         - name: preload-config
           configMap:
             name: "{{ template "fullname" . }}-preload"
-            items:
-              - key: preload.yml
-                path: preload.yml
       containers:
         - name: {{ template "fullname" . }}-job
           image: "{{ .Values.keystone_init.image.repository }}:{{ .Values.keystone_init.image.tag }}"
@@ -42,10 +39,11 @@ spec:
             - name: KEYSTONE_CERT
               value: "{{ .Values.keystone_init.cert }}"
 {{ include "keystone_init_keystone_env" .Values.keystone_init.auth | indent 12 }}
+            - name: PRELOAD_PATH
+              value: "/config/preload.yml"
           volumeMounts:
             - name: preload-config
-              mountPath: /preload.yml
-              subPath: preload.yml
+              mountPath: /config
       {{- if .Values.keystone_init.serviceAccount }}
       serviceAccountName: {{ .Values.keystone_init.serviceAccount | quote }}
       {{- else if .Values.rbac.create }}

--- a/mysql-users-init/Chart.yaml
+++ b/mysql-users-init/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Chart to initialize users and databases in MySQL
 name: mysql-users-init
-version: 0.2.0
+version: 0.2.1

--- a/mysql-users-init/templates/mysql-users-init-job.yaml
+++ b/mysql-users-init/templates/mysql-users-init-job.yaml
@@ -23,9 +23,6 @@ spec:
         - name: preload-config
           configMap:
             name: "{{ template "fullname" . }}-preload"
-            items:
-              - key: preload.yml
-                path: preload.yml
       containers:
         - name: {{ template "fullname" . }}-job
           image: "{{ .Values.mysql_users_init.image.repository }}:{{ .Values.mysql_users_init.image.tag }}"
@@ -43,10 +40,11 @@ spec:
 {{ include "mysql_users_init_secret_env" .Values.mysql_users_init.mysql.username | indent 14 }}
             - name: MYSQL_INIT_PASSWORD
 {{ include "mysql_users_init_secret_env" .Values.mysql_users_init.mysql.password | indent 14 }}
+            - name: PRELOAD_PATH
+              value: "/config/preload.yml"
           volumeMounts:
             - name: preload-config
-              mountPath: /preload.yml
-              subPath: preload.yml
+              mountPath: /config
       {{- if .Values.mysql_users_init.serviceAccount }}
       serviceAccountName: {{ .Values.mysql_users_init.serviceAccount | quote }}
       {{- else if .Values.rbac.create }}


### PR DESCRIPTION
Subpath mounting is broken in several versions of Kubernetes due to
patches for a recent CVE. This removes subpaths mounts in
keystone-init and mysql-users-init to avoid these issues.