### PR TITLE
Remove subpath mounts in monasca-aggregator

### DIFF
--- a/monasca/Chart.yaml
+++ b/monasca/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 description: A Helm chart for Monasca running in Kubernetes
 name: monasca
-version: 0.6.2
+version: 0.6.3
 sources:
 - https://wiki.openstack.org/wiki/Monasca
 maintainers:
-- name: Michael Hoppal
-  email: michael.jam.hoppal@hpe.com
+- name: Tim Buckley
+  email: timothy.jas.buckley@hpe.com

--- a/monasca/templates/aggregator-deployment.yaml
+++ b/monasca/templates/aggregator-deployment.yaml
@@ -40,13 +40,9 @@ spec:
             value: "{{ template "kafka.fullname" . }}:9092"
         volumeMounts:
           - name: aggregator-config
-            mountPath: /aggregation-specifications.yaml
-            subPath: aggregation-specifications.yaml
+            mountPath: /specs
       volumes:
         - name: aggregator-config
           configMap:
             name: {{ template "aggregator.fullname" . }}
-            items:
-              - key: aggregation-specifications.yaml
-                path: aggregation-specifications.yaml
 {{- end }}

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -703,7 +703,7 @@ aggregator:
   name: aggregator
   image:
     repository: monasca/aggregator
-    tag: 0.1.4
+    tag: 0.2.0
     pullPolicy: IfNotPresent
   window_size: 60
   window_lag: 2


### PR DESCRIPTION
Due to a recent Kubernetes CVE, subpath mounts are broken in several
Kubernetes point releases. This removes unnecessary subpath mounts
from monasca-aggregator to preserve compatibility on affected k8s
versions.