### PR TITLE
[monasca] overrideUri for kafka/zookeeper, non-local traffic in agent

### DIFF
--- a/monasca/Chart.yaml
+++ b/monasca/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Monasca running in Kubernetes
 name: monasca
-version: 0.6.3
+version: 0.6.4
 sources:
 - https://wiki.openstack.org/wiki/Monasca
 maintainers:

--- a/monasca/requirements.lock
+++ b/monasca/requirements.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.2.4
 - name: kafka
   repository: http://monasca.io/monasca-helm/
-  version: 0.4.0
+  version: 0.4.2
 - name: storm
   repository: http://monasca.io/monasca-helm/
   version: 0.5.3
 - name: zookeeper
   repository: http://monasca.io/monasca-helm/
-  version: 0.3.7
-digest: sha256:5417c7d1ef2ef4c7d74fa9cb9d3b0de30323ac6d1e4b1fb8d2be06afe18a27cf
-generated: 2018-03-14T15:06:44.314227877-06:00
+  version: 0.3.8
+digest: sha256:d4518c0c9c2fe0c60929de067e1ebb39c1d4db8272917f5582bf649d91b572e5
+generated: 2018-04-17T12:40:23.242201764-06:00

--- a/monasca/requirements.yaml
+++ b/monasca/requirements.yaml
@@ -8,7 +8,7 @@ dependencies:
     condition: 'mysql.enabled, global.mysql.enabled'
     repository: 'https://kubernetes-charts.storage.googleapis.com/'
   - name: kafka
-    version: 0.4.0
+    version: 0.4.2
     condition: 'kafka.enabled, global.kafka.enabled'
     repository: 'http://monasca.io/monasca-helm/'
   - name: storm
@@ -16,6 +16,6 @@ dependencies:
     condition: 'storm.enabled, global.storm.enabled'
     repository: 'http://monasca.io/monasca-helm/'
   - name: zookeeper
-    version: 0.3.7
+    version: 0.3.8
     condition: 'zookeeper.enabled, global.zookeeper.enabled'
     repository: 'http://monasca.io/monasca-helm/'

--- a/monasca/templates/agent-daemonset.yaml
+++ b/monasca/templates/agent-daemonset.yaml
@@ -149,6 +149,8 @@ spec:
               value: {{ .Values.agent.forwarder.backlog_send_rate | quote }}
             - name: HOSTNAME_FROM_KUBERNETES
               value: "true"
+            - name: NON_LOCAL_TRAFFIC
+              value: {{ .Values.agent.forwarder.non_local_traffic | quote }}
       {{- if .Values.agent.serviceAccount }}
       serviceAccountName: {{ .Values.agent.serviceAccount | quote }}
       {{- else if .Values.rbac.create }}

--- a/monasca/templates/agent-deployment.yaml
+++ b/monasca/templates/agent-deployment.yaml
@@ -141,6 +141,8 @@ spec:
               value: {{ .Values.agent.forwarder.max_measurement_buffer_size | quote }}
             - name: BACKLOG_SEND_RATE
               value: {{ .Values.agent.forwarder.backlog_send_rate | quote }}
+            - name: NON_LOCAL_TRAFFIC
+              value: {{ .Values.agent.forwarder.non_local_traffic | quote }}
       {{- if .Values.agent.plugins.enabled }}
       volumes:
         - name: agent-config

--- a/monasca/templates/aggregator-deployment.yaml
+++ b/monasca/templates/aggregator-deployment.yaml
@@ -37,7 +37,11 @@ spec:
           - name: AGGREGATION_WINDOW_LAG
             value: {{ .Values.aggregator.window_lag | quote }}
           - name: KAFKA_URI
+          {{- if .Values.kafka.overrideUri }}
+            value: "{{ .Values.kafka.overrideUri }}"
+          {{- else }}
             value: "{{ template "kafka.fullname" . }}:9092"
+          {{- end }}
         volumeMounts:
           - name: aggregator-config
             mountPath: /specs

--- a/monasca/templates/api-deployment.yaml
+++ b/monasca/templates/api-deployment.yaml
@@ -37,7 +37,11 @@ spec:
             - name: LOG_LEVEL_CONSOLE
               value: {{ .Values.api.logging.log_level_console | quote }}
             - name: KAFKA_URI
+            {{- if .Values.kafka.overrideUri }}
+              value: "{{ .Values.kafka.overrideUri }}"
+            {{- else }}
               value: "{{ template "kafka.fullname" . }}:9092"
+            {{- end }}
             - name: INFLUX_HOST
               value: "{{ .Release.Name }}-influxdb"
             - name: INFLUX_PORT

--- a/monasca/templates/forwarder-deployment.yaml
+++ b/monasca/templates/forwarder-deployment.yaml
@@ -35,9 +35,17 @@ spec:
             - name: VERBOSE
               value: {{ .Values.forwarder.logging.verbose | quote }}
             - name: ZOOKEEPER_URL
+            {{- if .Values.zookeeper.overrideUri }}
+              value: "{{ .Values.zookeeper.overrideUri }}"
+            {{- else }}
               value: "{{ template "zookeeper.fullname" . }}:2181"
+            {{- end }}
             - name: KAFKA_URI
+            {{- if .Values.kafka.overrideUri }}
+              value: "{{ .Values.kafka.overrideUri }}"
+            {{- else }}
               value: "{{ template "kafka.fullname" . }}:9092"
+            {{- end }}
             - name: USE_INSECURE
               value: {{ .Values.forwarder.config.use_insecure | quote}}
             - name: MONASCA_ROLE

--- a/monasca/templates/notification-deployment.yaml
+++ b/monasca/templates/notification-deployment.yaml
@@ -60,9 +60,17 @@ spec:
             - name: MYSQL_DB_DATABASE
               value: "mon"
             - name: KAFKA_URI
+            {{- if .Values.kafka.overrideUri }}
+              value: "{{ .Values.kafka.overrideUri }}"
+            {{- else }}
               value: "{{ template "kafka.fullname" . }}:9092"
+            {{- end }}
             - name: ZOOKEEPER_URL
+            {{- if .Values.zookeeper.overrideUri }}
+              value: "{{ .Values.zookeeper.overrideUri }}"
+            {{- else }}
               value: "{{ template "zookeeper.fullname" . }}:2181"
+            {{- end }}
             - name: LOG_LEVEL
               value: {{ .Values.notification.log_level | quote }}
             - name: NF_PLUGINS

--- a/monasca/templates/persister-deployment.yaml
+++ b/monasca/templates/persister-deployment.yaml
@@ -28,9 +28,17 @@ spec:
             - name: VERBOSE
               value: {{ .Values.persister.logging.verbose | quote }}
             - name: ZOOKEEPER_URI
+            {{- if .Values.zookeeper.overrideUri }}
+              value: "{{ .Values.zookeeper.overrideUri }}"
+            {{- else }}
               value: "{{ template "zookeeper.fullname" . }}:2181"
+            {{- end }}
             - name: KAFKA_URI
+            {{- if .Values.kafka.overrideUri }}
+              value: "{{ .Values.kafka.overrideUri }}"
+            {{- else }}
               value: "{{ template "kafka.fullname" . }}:9092"
+            {{- end }}
             - name: INFLUX_PORT
               value: {{ .Values.influxdb.config.http.bind_address | quote }}
             - name: INFLUX_USER

--- a/monasca/templates/thresh-deployment.yaml
+++ b/monasca/templates/thresh-deployment.yaml
@@ -32,10 +32,17 @@ spec:
               value: "{{ .Values.thresh.wait.delay }}"
             - name: STORM_WAIT_TIMEOUT
               value: "{{ .Values.thresh.wait.timeout }}"
+            {{- if .Values.zookeeper.overrideUri }}
+            - name: ZOOKEEPER_SERVERS
+              value: "{{ (.Values.zookeeper.overrideUri | split ":")._0 }}"
+            - name: STORM_ZOOKEEPER_PORT
+              value: "{{ (.Values.zookeeper.overrideUri | split ":")._1 }}"
+            {{- else }}
             - name: ZOOKEEPER_SERVERS
               value: "{{ template "zookeeper.fullname" . }}"
             - name: STORM_ZOOKEEPER_PORT
               value: "2181"
+            {{- end }}
             - name: NIMBUS_SEEDS
               value: "{{ .Release.Name }}-nimbus"
             - name: METRIC_SPOUT_THREADS
@@ -67,7 +74,11 @@ spec:
             - name: THRESHOLDING_BOLT_TASKS
               value: "{{ .Values.thresh.bolt.thresholdingBoltTasks }}"
             - name: KAFKA_URI
+            {{- if .Values.kafka.overrideUri }}
+              value: "{{ .Values.kafka.overrideUri }}"
+            {{- else }}
               value: "{{ .Release.Name }}-kafka:9092"
+            {{- end }}
             - name: USE_SSL_ENABLED
               value: "{{ .Values.thresh.use_ssl_enabled | default "false" }}"
             - name: MYSQL_DB_HOST

--- a/monasca/templates/thresh-init-job.yaml
+++ b/monasca/templates/thresh-init-job.yaml
@@ -32,10 +32,17 @@ spec:
               value: "{{ .Values.storm.thresh.wait.delay }}"
             - name: STORM_WAIT_TIMEOUT
               value: "{{ .Values.storm.thresh.wait.timeout }}"
+            {{- if .Values.zookeeper.overrideUri }}
+            - name: ZOOKEEPER_SERVERS
+              value: "{{ (.Values.zookeeper.overrideUri | split ":")._0 }}"
+            - name: STORM_ZOOKEEPER_PORT
+              value: "{{ (.Values.zookeeper.overrideUri | split ":")._1 }}"
+            {{- else }}
             - name: ZOOKEEPER_SERVERS
               value: "{{ template "zookeeper.fullname" . }}"
             - name: STORM_ZOOKEEPER_PORT
               value: "2181"
+            {{- end }}
             - name: NIMBUS_SEEDS
               value: "{{ .Release.Name }}-storm-nimbus"
             - name: METRIC_SPOUT_THREADS
@@ -67,7 +74,11 @@ spec:
             - name: THRESHOLDING_BOLT_TASKS
               value: "{{ .Values.storm.thresh.bolt.thresholdingBoltTasks }}"
             - name: KAFKA_URI
+            {{- if .Values.kafka.overrideUri }}
+              value: "{{ .Values.kafka.overrideUri }}"
+            {{- else }}
               value: "{{ .Release.Name }}-kafka:9092"
+            {{- end }}
             - name: USE_SSL_ENABLED
               value: "{{ .Values.thresh.use_ssl_enabled | default "false" }}"
             - name: MYSQL_DB_HOST

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -139,6 +139,7 @@ agent:
     max_batch_size: 0
     max_measurement_buffer_size: -1
     backlog_send_rate: 5
+    non_local_traffic: "true"
   log_level: WARN
   insecure: False
   keystone:
@@ -1632,6 +1633,8 @@ alarm_definition_controller:
   version: v1
 
 kafka:
+  enabled: true
+  overrideUri: ''
   init:
     topics:
       - metrics:64:1
@@ -1641,3 +1644,7 @@ kafka:
       - events:12:1
       - 60-seconds-notifications:3:1
       - kafka-health-check:1:1
+
+zookeeper:
+  enabled: true
+  overrideUri: ''


### PR DESCRIPTION
Adds support for `kafka.overrideUri` and `zookeeper.overrideUri`. If
set, these values allow an external kafka/zookeeper to be used.

Also adds support for setting the `NON_LOCAL_TRAFFIC` variable in
monasca-agent. On some systems with strange IPv6 configuration, the
forwarder is unable to bind to `localhost` properly. Enabling
non-local traffic makes the forwarder bind to 0.0.0.0 instead, which
works around the problem.

Signed-off-by: Tim Buckley <timothy.jas.buckley@hpe.com>