### PR TITLE
[monasca-agent] Set `NON_LOCAL_TRAFFIC` in forwarder

### DIFF
--- a/monasca-agent/Chart.yaml
+++ b/monasca-agent/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 description: A Helm chart for Monasca-agent
 name: monasca-agent
-version: 0.2.2
+version: 0.2.3
 sources:
 - https://github.com/openstack/monasca-agent
 maintainers:
-- name: Michael Hoppal
-  email: michael.jam.hoppal@hpe.com
+- name: Tim Buckley
+  email: timothy.jas.buckley@hpe.com

--- a/monasca-agent/templates/daemonset.yaml
+++ b/monasca-agent/templates/daemonset.yaml
@@ -120,3 +120,5 @@ spec:
               value: {{ .Values.forwarder.backlog_send_rate | quote }}
             - name: HOSTNAME_FROM_KUBERNETES
               value: "true"
+            - name: NON_LOCAL_TRAFFIC
+              value: {{ .Values.forwarder.non_local_traffic | quote }}

--- a/monasca-agent/templates/deployment.yaml
+++ b/monasca-agent/templates/deployment.yaml
@@ -127,6 +127,8 @@ spec:
               value: {{ .Values.forwarder.backlog_send_rate | quote }}
             - name: HOSTNAME_FROM_KUBERNETES
               value: "true"
+            - name: NON_LOCAL_TRAFFIC
+              value: {{ .Values.forwarder.non_local_traffic | quote }}
       {{- if .Values.plugins.enabled }}
       volumes:
         - name: agent-config

--- a/monasca-agent/values.yaml
+++ b/monasca-agent/values.yaml
@@ -16,6 +16,7 @@ forwarder:
   max_batch_size: 0
   max_measurement_buffer_size: -1
   backlog_send_rate: 5
+  non_local_traffic: "true"
 insecure: False
 log_level: WARN
 keystone:


### PR DESCRIPTION
Also adds support for setting the `NON_LOCAL_TRAFFIC` variable in
monasca-agent. On some systems with strange IPv6 configuration, the
forwarder is unable to bind to `localhost` properly. Enabling
non-local traffic makes the forwarder bind to 0.0.0.0 instead, which
works around the problem. As we're running in a container and no
ports are exposed by default, this workaround should be safe to apply
automatically.

Signed-off-by: Tim Buckley <timothy.jas.buckley@hpe.com>