### PR TITLE
auto-update: keystone-init -> 1.3.0

### DIFF
--- a/keystone-init/Chart.yaml
+++ b/keystone-init/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Chart to initialize users in Keystone
 name: keystone-init
-version: 0.3.3
+version: 0.4.0

--- a/keystone-init/values.yaml
+++ b/keystone-init/values.yaml
@@ -11,7 +11,7 @@ keystone_init:
 
   image:
     repository: monasca/keystone-init
-    tag: 1.2.2
+    tag: 1.3.0
     pullPolicy: IfNotPresent
 
   # general options for the init job


### PR DESCRIPTION
Dependency `keystone-init` from dockerhub repository monasca-docker
was updated to version `1.3.0`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: keystone-init
Source-Module-Type: docker
Destination-Module: keystone-init
Destination-Module-Type: helm
