### PR TITLE
auto-update: aggregator -> 0.2.1

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -704,7 +704,7 @@ aggregator:
   name: aggregator
   image:
     repository: monasca/aggregator
-    tag: 0.2.0
+    tag: 0.2.1
     pullPolicy: IfNotPresent
   window_size: 60
   window_lag: 2


### PR DESCRIPTION
Dependency `aggregator` from dockerhub repository monasca-docker was
updated to version `0.2.1`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: aggregator
Source-Module-Type: docker
Destination-Module: monasca
Destination-Module-Type: helm
