### PR TITLE
auto-update: agent-forwarder -> master-20180709-110140

### DIFF
--- a/monasca-agent/values.yaml
+++ b/monasca-agent/values.yaml
@@ -11,7 +11,7 @@ collector:
 forwarder:
   image:
     repository: monasca/agent-forwarder
-    tag: master-20180206-002800
+    tag: master-20180709-110140
     pullPolicy: IfNotPresent
   max_batch_size: 0
   max_measurement_buffer_size: -1


### PR DESCRIPTION
Dependency `agent-forwarder` from dockerhub repository monasca-docker
was updated to version `master-20180709-110140`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: agent-forwarder
Source-Module-Type: docker
Destination-Module: monasca-agent
Destination-Module-Type: helm
