### PR TITLE
auto-update: agent-collector -> master-20180709-110140

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -125,7 +125,7 @@ agent:
   collector:
     image:
       repository: monasca/agent-collector
-      tag: master-20180112-162543
+      tag: master-20180709-110140
       pullPolicy: IfNotPresent
     check_freq: 30
     num_collector_threads: 1


### PR DESCRIPTION
Dependency `agent-collector` from dockerhub repository monasca-docker
was updated to version `master-20180709-110140`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: agent-collector
Source-Module-Type: docker
Destination-Module: monasca
Destination-Module-Type: helm
