### PR TITLE
auto-update: grafana-init -> 1.4.0

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -35,7 +35,7 @@ influx_init:
 grafana_init:
   image:
     repository: monasca/grafana-init
-    tag: 1.2.1
+    tag: 1.4.0
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
Dependency `grafana-init` from dockerhub repository monasca-docker was
updated to version `1.4.0`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: grafana-init
Source-Module-Type: docker
Destination-Module: monasca
Destination-Module-Type: helm
