### PR TITLE
auto-update: grafana -> 4.0.0-1.5.1

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -286,7 +286,7 @@ grafana:
   enabled: true
   image:
     repository: monasca/grafana
-    tag: 4.0.0-1.4.1
+    tag: 4.0.0-1.5.1
     pullPolicy: IfNotPresent
   service:
     type: NodePort


### PR DESCRIPTION
Dependency `grafana` from dockerhub repository monasca-docker was
updated to version `4.0.0-1.5.1`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: grafana
Source-Module-Type: docker
Destination-Module: monasca
Destination-Module-Type: helm
