### PR TITLE
auto-update: agent-collector -> master-20190103-134212

### DIFF
--- a/monasca-agent/values.yaml
+++ b/monasca-agent/values.yaml
@@ -2,7 +2,7 @@ name: agent
 collector:
   image:
     repository: monasca/agent-collector
-    tag: master-20180112-162543
+    tag: master-20190103-134212
     pullPolicy: IfNotPresent
   check_freq: 30
   num_collector_threads: 1


### PR DESCRIPTION
Dependency `agent-collector` from dockerhub repository monasca-docker
was updated to version `master-20190103-134212`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: agent-collector
Source-Module-Type: docker
Destination-Module: monasca-agent
Destination-Module-Type: helm
