### PR TITLE
keystone config fixed pod ip ,service can not access when pods rebuild

### DIFF
--- a/monasca/templates/keystone-deployment.yaml
+++ b/monasca/templates/keystone-deployment.yaml
@@ -32,9 +32,7 @@ spec:
 {{ toYaml .Values.keystone.resources | indent 12 }}
           env:
             - name: KEYSTONE_HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
+              value: {{ .Values.keystone.name | quote }}
             - name: KEYSTONE_USERNAME
               value: {{ .Values.keystone.bootstrap.user | quote }}
             - name: KEYSTONE_PASSWORD


### PR DESCRIPTION
https://github.com/monasca/monasca-helm/issues/438

keystone deployment config keystone host with pod fixed ip.when pod rebuild,other components can not access right keystone service.
it is more reasonable use keystone service name than pod fixed ip.