### PR TITLE
auto-update: keystone -> 1.2.0

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -322,7 +322,7 @@ keystone:
   database_backend: mysql
   image:
     pullPolicy: IfNotPresent
-    tag: 1.1.3
+    tag: 1.2.0
     repository: monasca/keystone
   mysql:
     database: keystone


### PR DESCRIPTION
Dependency `keystone` from dockerhub repository monasca-docker was
updated to version `1.2.0`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: keystone
Source-Module-Type: docker
Destination-Module: monasca
Destination-Module-Type: helm
