### PR TITLE
auto-update: agent-forwarder -> master

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -134,7 +134,7 @@ agent:
   forwarder:
     image:
       repository: monasca/agent-forwarder
-      tag: master-20180206-002800
+      tag: master
       pullPolicy: IfNotPresent
     max_batch_size: 0
     max_measurement_buffer_size: -1


### PR DESCRIPTION
Dependency `agent-forwarder` from dockerhub repository monasca-docker
was updated to version `master`.

Source-Repository-Type: dockerhub
Source-Repository: monasca
Source-Module: agent-forwarder
Source-Module-Type: docker
Destination-Module: monasca
Destination-Module-Type: helm
