### PR TITLE
keystone and supervisor config modify

### DIFF
--- a/monasca/templates/keystone-deployment.yaml
+++ b/monasca/templates/keystone-deployment.yaml
@@ -32,9 +32,7 @@ spec:
 {{ toYaml .Values.keystone.resources | indent 12 }}
           env:
             - name: KEYSTONE_HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
+              value: {{ template "keystone.fullname" . }}
             - name: KEYSTONE_USERNAME
               value: {{ .Values.keystone.bootstrap.user | quote }}
             - name: KEYSTONE_PASSWORD

--- a/storm/templates/supervisor-deployment.yaml
+++ b/storm/templates/supervisor-deployment.yaml
@@ -35,26 +35,4 @@ spec:
               value: "{{ template "storm.fullname" . }}-nimbus"
             - name: SUPERVISOR_SLOTS_PORTS
               value: {{ .Values.supervisor_ports | join "," | quote }}
-            - name: METRIC_SPOUT_THREADS
-              value: "{{ .Values.thresh.spout.metricSpoutThreads }}"
-            - name: METRIC_SPOUT_TASKS
-              value: "{{ .Values.thresh.spout.metricSpoutTasks }}"
-            - name: KAFKA_URI
-              value: "{{ .Release.Name }}-kafka:9092"
-            - name: MYSQL_DB_HOST
-              value: "{{ .Release.Name }}-mysql"
-            - name: MYSQL_DB_PORT
-              value: "3306"
-            - name: MYSQL_DB_DATABASE
-              value: "mon"
-            - name: MYSQL_DB_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Release.Name }}-{{ .Values.thresh.secretSuffix }}"
-                  key: username
-            - name: MYSQL_DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Release.Name }}-{{ .Values.thresh.secretSuffix }}"
-                  key: password
 {{- end}}


### PR DESCRIPTION
So far keystone init mysql user keystone pod ip, when pod restart or recreated, keystone pod ip will change, and data stored in mysql will not match real keystone pod. So it should use keystone service name

These variables are initd by thresh job, so they are not needed in supervisor deployment yaml