### PR TITLE
Change references to monasca.io to monasca.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Monasca Helm
 
 This repo contains Helm charts for Monasca and its dependencies. Each chart release is hosted on
-[monasca.io](http://monasca.io) via github pages.
+[monasca.github.io](https://monasca.github.io) via github pages.
 
 ## Quick Start
 
 To install Monasca in Kubernetes you can follow the following steps:
 
 ```bash
-$ helm repo add monasca http://monasca.io/monasca-helm
+$ helm repo add monasca https://monasca.github.io/monasca-helm
 $ helm install monasca/monasca --name monasca --namespace monitoring
 ```
 
@@ -41,4 +41,4 @@ $ kubectl port-forward {{ grafana_pod_name_from_output_above }} -n monitoring 30
 After the above is set up you can visit [grafana](http://localhost:3000) with the default credentials mini-mon/password
 
 For more details on configuring the Monasca chart you can refer to the chart's [README](monasca/README.md) and for
-general details around Monasca in Kubernetes you can refer to [monasca.io](http://monasca.io/docs/kubernetes.html)
+general details around Monasca in Kubernetes you can refer to [monasca.github.io](http://monasca.github.io/docs/kubernetes.html)

--- a/ci.py
+++ b/ci.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #

--- a/monasca-alarms/README.md
+++ b/monasca-alarms/README.md
@@ -17,7 +17,7 @@ alarms generated as the threshold engine requires kafka to be working.
 ## QuickStart
 
 ```bash
-$ helm repo add monasca http://monasca.io/monasca-helm
+$ helm repo add monasca https://monasca.github.io/monasca-helm
 $ helm install monasca/monasca --name monasca --namespace monitoring
 $ helm install monasca/monasca-alarms --name monasca-alarms --namespace monitoring
 ```
@@ -34,7 +34,7 @@ deployment on a Kubernetes cluster using the Helm Package manager.
 
 ## Installing the Chart
 
-Monasca-alarms can either be installed from the [monasca.io](https://monasca.io/) helm repo or by source.
+Monasca-alarms can either be installed from the [monasca.github.io](https://monasca.github.io/) helm repo or by source.
 
 ### Installing via Helm repo (recommended)
 
@@ -46,7 +46,7 @@ Note: monasca-alarms must be installed in the same namespace as monasca
 ### Installing via source
 
 ```bash
-$ helm repo add monasca http://monasca.io/monasca-helm
+$ helm repo add monasca http://monasca.github.io/monasca-helm
 $ helm dependency update monasca-alarms
 $ helm install monasca-alarms --name monasca-alarms --namespace monitoring
 ```

--- a/monasca/README.md
+++ b/monasca/README.md
@@ -13,7 +13,7 @@ storing, alarming and notifications. The architecture can be viewed
 ## QuickStart
 
 ```bash
-$ helm repo add monasca http://monasca.io/monasca-helm
+$ helm repo add monasca https://monasca.github.io/monasca-helm
 $ helm install monasca/monasca --name monasca --namespace monitoring
 ```
 
@@ -28,19 +28,19 @@ deployment on a Kubernetes cluster using the Helm Package manager.
 
 ## Installing the Chart
 
-Monasca can either be install from the [monasca.io](https://monasca.io/) helm repo or by source.
+Monasca can either be install from the [monasca.github.io](https://monasca.github.io/) helm repo or by source.
 
 ### Installing via Helm repo (recommended)
 
 ```bash
-$ helm repo add monasca http://monasca.io/monasca-helm
+$ helm repo add monasca https://monasca.github.io/monasca-helm
 $ helm install monasca/monasca --name monasca --namespace monitoring
 ```
 
 ### Installing via source
 
 ```bash
-$ helm repo add monasca http://monasca.io/monasca-helm
+$ helm repo add monasca https://monasca.github.io/monasca-helm
 $ helm dependency update monasca
 $ helm install monasca --name monasca --namespace monitoring
 ```
@@ -73,7 +73,7 @@ It will also autodetect Prometheus Endpoints by looking for the following annota
 * prometheus.io/port: Scrape the pod on the indicated port instead of the default of '9102'.
 
 More information on our monitoring within in Kubernetes can be found on
-[monasca.io](http://monasca.io/docs/kubernetes.html)
+[monasca.github.io](https://monasca.github.io/docs/kubernetes.html)
 
 ## Configuration
 

--- a/monasca/requirements.lock
+++ b/monasca/requirements.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: influxdb
-  repository: http://monasca.io/monasca-helm/
+  repository: https://monasca.github.io/monasca-helm/
   version: 0.6.2-0.0.2
 - name: mysql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.2.4
 - name: kafka
-  repository: http://monasca.io/monasca-helm/
+  repository: https://monasca.github.io/monasca-helm/
   version: 0.4.2
 - name: storm
-  repository: http://monasca.io/monasca-helm/
+  repository: https://monasca.github.io/monasca-helm/
   version: 0.5.3
 - name: zookeeper
-  repository: http://monasca.io/monasca-helm/
+  repository: https://monasca.github.io/monasca-helm/
   version: 0.3.8
 digest: sha256:d4518c0c9c2fe0c60929de067e1ebb39c1d4db8272917f5582bf649d91b572e5
 generated: 2018-04-17T12:40:23.242201764-06:00

--- a/monasca/requirements.yaml
+++ b/monasca/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
   - name: influxdb
     version: 0.6.2-0.0.2
     condition: 'influxdb.enabled, global.influxdb.enabled'
-    repository: 'http://monasca.io/monasca-helm/'
+    repository: 'https://monasca.github.io/monasca-helm/'
   - name: mysql
     version: 0.2.4
     condition: 'mysql.enabled, global.mysql.enabled'
@@ -10,12 +10,12 @@ dependencies:
   - name: kafka
     version: 0.4.2
     condition: 'kafka.enabled, global.kafka.enabled'
-    repository: 'http://monasca.io/monasca-helm/'
+    repository: 'https://monasca.github.io/monasca-helm/'
   - name: storm
     version: 0.5.3
     condition: 'storm.enabled, global.storm.enabled'
-    repository: 'http://monasca.io/monasca-helm/'
+    repository: 'https://monasca.github.io/monasca-helm/'
   - name: zookeeper
     version: 0.3.8
     condition: 'zookeeper.enabled, global.zookeeper.enabled'
-    repository: 'http://monasca.io/monasca-helm/'
+    repository: 'https://monasca.github.io/monasca-helm/'

--- a/push.sh
+++ b/push.sh
@@ -12,7 +12,7 @@ git config --global user.name "Monasca CI"
 ./helm init -c
 
 # Build Helm Charts
-./helm repo add monasca http://monasca.io/monasca-helm/
+./helm repo add monasca https://monasca.github.io/monasca-helm/
 
 for chart in "$@"
 do
@@ -31,7 +31,7 @@ cp *.tgz out/.
 
 # Update index file
 cd out
-../helm repo index . --url http://monasca.io/monasca-helm/
+../helm repo index . --url https://monasca.github.io/monasca-helm/
 
 # Commit changes
 git add *.tgz

--- a/transform/requirements.lock
+++ b/transform/requirements.lock
@@ -3,7 +3,7 @@ dependencies:
   enabled: false
   import-values: null
   name: spark
-  repository: http://monasca.io/monasca-helm/
+  repository: https://monasca.github.io/monasca-helm/
   tags: null
   version: 0.2.0
 digest: sha256:c9b41d3ce2c858385409b9ddbe6b18dd948f084bc9056ff2e72ccd7c2e75cfc5

--- a/transform/requirements.yaml
+++ b/transform/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: spark
     version: 0.2.0
-    repository: http://monasca.io/monasca-helm/
+    repository: https://monasca.github.io/monasca-helm/


### PR DESCRIPTION
This changes all references to monasca.io to point to
monasca.github.io. This may be reverted once the domain situation is
resolved.